### PR TITLE
make force_cuda_init inline

### DIFF
--- a/src/cuda/api/miscellany.hpp
+++ b/src/cuda/api/miscellany.hpp
@@ -21,6 +21,7 @@ namespace cuda {
  * is done on the device etc. This function forces this initialization to
  * happen immediately, while not having any other effect.
  */
+inline
 void force_runtime_initialization()
 {
 	// nVIDIA's Robin Thoni (https://www.rthoni.com/) guarantees


### PR DESCRIPTION
j3yj3y forked the wrappers because force_cuda_init wasn't inlined, which prevents inclusion from multiple TUs.