### PR TITLE
fix compilation when #ifndef NDEBUG

### DIFF
--- a/src/cuda/api/multi_wrapper_impls.hpp
+++ b/src/cuda/api/multi_wrapper_impls.hpp
@@ -106,9 +106,9 @@ template <bool AssumesDeviceIsCurrent>
 void stream_t<AssumesDeviceIsCurrent>::enqueue_t::wait(const event_t& event_)
 {
 #ifndef NDEBUG
-	if (event_.device_id() != device_id()) {
+	if (event_.device_id() != device_id_) {
 		throw std::invalid_argument("Attempt to have a stream on CUDA device "
-			+ std::to_string(device_id()) + " wait for an event on another device ("
+			+ std::to_string(device_id_) + " wait for an event on another device ("
 			"device " + std::to_string(event_.device_id()) + ")");
 	}
 #endif
@@ -129,9 +129,9 @@ template <bool AssumesDeviceIsCurrent>
 void stream_t<AssumesDeviceIsCurrent>::enqueue_t::event(const event_t& event_)
 {
 #ifndef NDEBUG
-	if (event_.device_id() != device_id()) {
+	if (event_.device_id() != device_id_) {
 		throw std::invalid_argument("Attempt to have a stream on CUDA device "
-			+ std::to_string(device_id()) + " wait for an event on another device ("
+			+ std::to_string(device_id_) + " wait for an event on another device ("
 			"device " + std::to_string(event_.device_id()) + ")");
 	}
 #endif


### PR DESCRIPTION
Building the examples with gcc 6.3 and cuda 9.1 fails with
```
cuda-api-wrappers/src/cuda/api/multi_wrapper_impls.hpp(109): error: class "cuda::stream_t<AssumesDeviceIsCurrent>::enqueue_t [with AssumesDeviceIsCurrent=false]" has no member "device_id"
          detected during instantiation of "void cuda::stream_t<AssumesDeviceIsCurrent>::enqueue_t::wait(const cuda::event_t &) [with AssumesDeviceIsCurrent=false]" 
cuda-api-wrappers/examples/by_runtime_api_module/stream_management.cu(147): here

cuda-api-wrappers/src/cuda/api/multi_wrapper_impls.hpp(111): error: class "cuda::stream_t<AssumesDeviceIsCurrent>::enqueue_t [with AssumesDeviceIsCurrent=false]" has no member "device_id"
          detected during instantiation of "void cuda::stream_t<AssumesDeviceIsCurrent>::enqueue_t::wait(const cuda::event_t &) [with AssumesDeviceIsCurrent=false]" 
cuda-api-wrappers/examples/by_runtime_api_module/stream_management.cu(147): here

2 errors detected in the compilation of "stream_management.cpp1.ii".
CMake Error at stream_management_generated_stream_management.cu.o.cmake:262 (message):
  Error generating file
  build/CMakeFiles/stream_management.dir/examples/by_runtime_api_module/./stream_management_generated_stream_management.cu.o
```

Changing the call to `device_id()` with the access to the data member `device_id_` works around the problem.