### PR TITLE
Fix/cooperative launch

### DIFF
--- a/examples/by_runtime_api_module/execution_control.cu
+++ b/examples/by_runtime_api_module/execution_control.cu
@@ -150,6 +150,7 @@ int main(int argc, char **argv)
 #ifdef _CG_HAS_GRID_GROUP
 	// And finally, some "cooperative" vs ""uncooperative"  kernel launches
 	if (cuda::version_numbers::runtime() >= 9) {
+		const auto kernel = grid_cooperating_foo;
 		std::cout
 			<< "Launching kernel " << kernel_name
 			<< " with " << num_blocks << " blocks, cooperatively, using stream.launch()\n"

--- a/examples/by_runtime_api_module/execution_control.cu
+++ b/examples/by_runtime_api_module/execution_control.cu
@@ -15,7 +15,9 @@
 #include "cuda/api_wrappers.h"
 
 #include <cuda_runtime_api.h>
+#if __CUDACC_VER_MAJOR__ >= 9
 #include <cooperative_groups.h>
+#endif
 
 #include <iostream>
 #include <string>

--- a/src/cuda/api/error.hpp
+++ b/src/cuda/api/error.hpp
@@ -179,6 +179,15 @@ public:
 		std::runtime_error(what_arg + ": " + describe(error_code)),
 		code_(error_code)
 	{ }
+	runtime_error(cuda::status::alias_t error_code) :
+		std::runtime_error(describe((cuda::status_t) error_code)),
+		code_((cuda::status_t) error_code)
+	{ }
+	runtime_error(cuda::status::alias_t error_code, const std::string& what_arg) :
+		std::runtime_error(what_arg + ": " + describe((cuda::status_t) error_code)),
+		code_((cuda::status_t) error_code)
+	{ }
+
 	///@endcond
 
 	/**

--- a/src/cuda/api/kernel_launch.cuh
+++ b/src/cuda/api/kernel_launch.cuh
@@ -92,7 +92,7 @@ void for_each_argument_address(F f, Args&&... args) {
  * commands etc. - if you want those, write an additional wrapper (perhaps calling this one in turn).
  *
  * @param cooperative if true, use CUDA's "cooperative launch" mechanism which enables more flexible
- * synchronization capabilities (see
+ * synchronization capabilities (see CUDA C Programming Guide C.3. Grid Synchronization)
  * @param kernel_function the kernel to apply. Pass it just as-it-is, as though it were any other function. Note:
  * If the kernel is templated, you must pass it fully-instantiated.
  * @param stream_id the CUDA hardware command queue on which to place the command to launch the kernel (affects

--- a/src/cuda/api/kernel_launch.cuh
+++ b/src/cuda/api/kernel_launch.cuh
@@ -42,7 +42,6 @@
 #ifndef CUDA_API_WRAPPERS_KERNEL_LAUNCH_CUH_
 #define CUDA_API_WRAPPERS_KERNEL_LAUNCH_CUH_
 
-#include <iostream>
 #include <cuda/api/types.h>
 #include <cuda/api/constants.h>
 #include <cuda/api/device_function.hpp>


### PR DESCRIPTION
Issues fixed:

- example `execution_control` not compileable with CUDA 8
- `cudaLaunchCooperativeKernel` was never called
- `cudaLaunchCooperativeKernel` was given the wrong kernel address