### PR TITLE
Fix call to "cudaHostRegister"

### DIFF
--- a/src/cuda/api/memory.hpp
+++ b/src/cuda/api/memory.hpp
@@ -388,9 +388,9 @@ inline void register_(void *ptr, size_t size,
 {
 	detail::register_(
 		ptr, size,
-		  register_mapped_io_space ? cudaHostRegisterIoMemory : 0
-		| map_into_device_space ? cudaHostRegisterMapped : 0
-		| make_device_side_accesible_to_all ? cudaHostRegisterPortable : 0
+		  (register_mapped_io_space ? cudaHostRegisterIoMemory : 0)
+		| (map_into_device_space ? cudaHostRegisterMapped : 0)
+		| (make_device_side_accesible_to_all ? cudaHostRegisterPortable : 0)
 	);
 }
 


### PR DESCRIPTION
The flags are expected to orthogonal to each others as in a bitflag (see: [cudaHostRegister](http://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1ge8d5c17670f16ac4fc8fcb4181cb490c) )
Ternary operator has a lower precedence than bitwise-or. Hence, the behaviour was not the one expected.

Very usefull library ;-)