### PR TITLE
Change the friend declaration to make clang happy

### DIFF
--- a/src/cuda/api/stream.hpp
+++ b/src/cuda/api/stream.hpp
@@ -477,7 +477,7 @@ protected: // constructor
 
 public: // friendship
 
-	friend stream_t<> stream::wrap(device::id_t device_id, id_t stream_id, bool take_ownership);
+	friend stream_t<> stream::wrap(device::id_t device_id, stream::id_t stream_id, bool take_ownership);
 
 protected: // data members
 	const device::id_t  device_id_;


### PR DESCRIPTION
Without this change, compilation with clang++ fails with
> ```
> In file included from .../cuda/api_wrappers.h:28:
> .../cuda/api/stream.hpp:510:9: error: calling a protected constructor of class 'cuda::stream_t<false>'
>         return stream_t<>(device_id, stream_id, take_ownership);
>                ^
> .../cuda/api/stream.hpp:454:2: note: declared protected here
>         stream_t(device::id_t device_id, stream::id_t stream_id, bool take_ownership)
>         ^
> ```
I have no idea if clang is right to complain or not, but the workaround seems trivial enough.