### PR TITLE
Target based cmake style; build directory export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
+option(EXPORT_BUILD_DIR "Export build directory using CMake (enables external use without install)" OFF)
+set(CMAKE_DISABLE_SOURCE_CHANGES ON)
+set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+
 # -----------------------------------
 # Project name, version & build type
 # -----------------------------------
@@ -32,8 +36,10 @@ endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
-PROJECT(cuda-api-wrappers
-	LANGUAGES CUDA CXX)
+PROJECT(
+	cuda-api-wrappers
+	LANGUAGES CUDA CXX
+)
 
 #	# No versioning for now
 #
@@ -47,42 +53,21 @@ PROJECT(cuda-api-wrappers
 # General C++ build settings
 # ----------------------------
 
+# Here we set a PRIVATE compile option for all targets in this project
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic" )
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
-include_directories( "src/" )
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # -------------
 # CUDA
 # -------------
-
-#find_package(CUDA 7.0 REQUIRED) # Why do I to do this damn it ?!
-#include_directories( "${CUDA_TOOLKIT_INCLUDE}" )
-include_directories( ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} )
 include(HandleCUDAComputeCapability)
 
+# Here we set a PRIVATE compile option for all targets in this project
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wall" )
-set(CMAKE_CUDA_STANDARD 11)
+
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_EXTENSIONS ON)
-
-set(CUDA_SEPARABLE_COMPILATION ON) # Does this work with native CUDA support?
-set(CUDA_PROPAGATE_HOST_FLAGS OFF) # Does this work with native CUDA support?
-
-# This should really have been automatic...
-#get_filename_component(CUDA_LIBRARY_DIR ${CUDA_CUDART_LIBRARY} DIRECTORY)
-#set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} "-L${CUDA_LIBRARY_DIR}" )
-
-#set(CUDA_LIBRARIES ${CUDA_LIBRARIES} ${CUDA_NVTX_LIBRARY} ${CUDA_cudadevrt_LIBRARY})
-
-# The FindCUDA script forces the use of the libcublas library when perform device linkage;
-# but on some systems and in certain situations, its inclusion on the command line
-# triggers various kinds of errors; so - we ensure it is empty and unused
-#set(CUDA_cublas_device_LIBRARY "" CACHE FILEPATH "Path of the CUBLAS library - unused dummy value" FORCE)
-
-
 
 # -----------------------
 # Main target(s)
@@ -95,87 +80,151 @@ add_library(
 	cuda-api-wrappers
 	src/cuda/api/device_properties.cpp
 	src/cuda/api/profiling.cpp
-	src/cuda/api/ipc.hpp
-	src/cuda/api/event.hpp
-	src/cuda/api/device_properties.hpp
-	src/cuda/api/pointer.hpp
-	src/cuda/api/multi_wrapper_impls.hpp
-	src/cuda/api/current_device.hpp
-	src/cuda/api/peer_to_peer.hpp
-	src/cuda/api/device.hpp
-	src/cuda/api/pci_id.hpp
-	src/cuda/api/versions.hpp
-	src/cuda/api/unique_ptr.hpp
-	src/cuda/api/memory.hpp
-	src/cuda/api/device_count.hpp
-	src/cuda/api/stream.hpp
-	src/cuda/api/error.hpp
-	src/cuda/api/device_function.hpp
-	src/cuda/api/miscellany.hpp
 )
+
+# CUDA_STANDARD can not be set as `compile_feature` yet. Thus we
+# set the c++ standard, since that is used in the header part of
+# this library, to force users of this library to compile automatically
+# with c++11 compatible standards.
+set_target_properties(cuda-api-wrappers PROPERTIES CUDA_STANDARD 11)
+target_compile_features(cuda-api-wrappers PUBLIC cxx_std_11)
+
+target_include_directories(
+	cuda-api-wrappers
+	PUBLIC
+		"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
+		"$<INSTALL_INTERFACE:include>"
+)
+
+target_link_libraries(cuda-api-wrappers cudart)
+
+# To enable `target_link_library(foo cuda-api-wrappers::cuda-api-wrappers)`
+# in other CMake projects, which include this project with `add_subdirectory`
+add_library(cuda-api-wrappers::cuda-api-wrappers ALIAS cuda-api-wrappers)
 
 # -----------------------
 # Examples / Tests
 # -----------------------
 
-find_library(CUDART_LIBRARY cudart ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
-link_libraries(cuda-api-wrappers ${CUDART_LIBRARY})
-
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "examples/bin")
+
 add_executable(vectorAdd EXCLUDE_FROM_ALL examples/modified_cuda_samples/vectorAdd/vectorAdd.cu)
+target_link_libraries(vectorAdd cuda-api-wrappers)
+
 add_executable(inlinePTX EXCLUDE_FROM_ALL examples/modified_cuda_samples/inlinePTX/inlinePTX.cu)
+target_link_libraries(inlinePTX cuda-api-wrappers)
+
 add_executable(simpleStreams EXCLUDE_FROM_ALL examples/modified_cuda_samples/simpleStreams/simpleStreams.cu)
+target_link_libraries(simpleStreams cuda-api-wrappers)
+
 add_executable(simpleIPC EXCLUDE_FROM_ALL examples/modified_cuda_samples/simpleIPC/simpleIPC.cu)
+target_link_libraries(simpleIPC cuda-api-wrappers)
+
 #----
 add_custom_target(modified_cuda_samples)
-add_dependencies(modified_cuda_samples vectorAdd inlinePTX simpleStreams simpleIPC)
-
-add_executable(version_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/version_management.cpp)
-target_link_libraries(version_management  ${CUDA_LIBRARIES})
-add_executable(error_handling EXCLUDE_FROM_ALL examples/by_runtime_api_module/error_handling.cu)
-add_executable(device_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/device_management.cpp)
-add_executable(execution_control EXCLUDE_FROM_ALL examples/by_runtime_api_module/execution_control.cu)
-target_compile_options(execution_control PRIVATE -rdc true)
-add_executable(stream_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/stream_management.cu)
-add_executable(event_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/event_management.cu)
-add_executable(io_compute_overlap_with_streams EXCLUDE_FROM_ALL examples/other/io_compute_overlap_with_streams.cu)
-#----
-add_custom_target(examples_by_runtime_api_module)
-add_dependencies(examples_by_runtime_api_module
-	version_management
-	error_handling device_management
-	execution_control
-	stream_management
-	event_management
-	io_compute_overlap_with_streams
+add_dependencies(
+	modified_cuda_samples
+		vectorAdd
+		inlinePTX
+		simpleStreams
+		simpleIPC
 )
 
+#----
+add_executable(version_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/version_management.cpp)
+target_link_libraries(version_management cuda-api-wrappers)
+
+add_executable(error_handling EXCLUDE_FROM_ALL examples/by_runtime_api_module/error_handling.cu)
+target_link_libraries(error_handling cuda-api-wrappers)
+
+add_executable(device_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/device_management.cpp)
+target_link_libraries(device_management cuda-api-wrappers)
+
+add_executable(execution_control EXCLUDE_FROM_ALL examples/by_runtime_api_module/execution_control.cu)
+target_link_libraries(execution_control cuda-api-wrappers)
+target_compile_options(execution_control PRIVATE -rdc true)
+
+add_executable(stream_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/stream_management.cu)
+target_link_libraries(stream_management cuda-api-wrappers)
+
+add_executable(event_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/event_management.cu)
+target_link_libraries(event_management cuda-api-wrappers)
+
+add_executable(io_compute_overlap_with_streams EXCLUDE_FROM_ALL examples/other/io_compute_overlap_with_streams.cu)
+target_link_libraries(io_compute_overlap_with_streams cuda-api-wrappers)
+
+add_executable(ipc EXCLUDE_FROM_ALL examples/by_runtime_api_module/ipc.cpp)
+target_link_libraries(ipc cuda-api-wrappers)
+
+#----
+add_custom_target(examples_by_runtime_api_module)
+add_dependencies(
+	examples_by_runtime_api_module
+		version_management
+		error_handling
+		device_management
+		execution_control
+		stream_management
+		event_management
+		io_compute_overlap_with_streams
+		ipc
+)
+
+#----
 add_custom_target(examples)
 add_dependencies(examples examples_by_runtime_api_module modified_cuda_samples)
 
+#----
 add_custom_target(docs
 	COMMAND doxygen doxygen.cfg
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 
-add_dependencies(examples examples_by_runtime_api_module modified_cuda_samples)
-
-# -------------
-
+#-----
 install(
 	TARGETS cuda-api-wrappers
 	EXPORT cuda-api-wrappers
 	ARCHIVE # For CMake, a static library is an ARCHIVE, a dynamic library is a RUNTIME
 	DESTINATION lib
 	INCLUDES DESTINATION include
-	CONFIGURATIONS Release RelWithDebugInfo
 )
 
 install(
-#	EXPORT cuda-api-wrappers
 	DIRECTORY src/cuda
 	DESTINATION include
 	FILES_MATCHING REGEX "\\.(h|hpp|cuh)"
 )
 
-export(EXPORT cuda-api-wrappers FILE cuda-api-wrappers.cmake)
+#set(RELATIVE_CONFIG_INSTALL_DIR "share/cmake/cuda-api-wrappers-${PROJECT_VERSION}")
+# since there is no versioning yet:
+set(RELATIVE_CONFIG_INSTALL_DIR "share/cmake/cuda-api-wrappers")
+
+install(
+	EXPORT cuda-api-wrappers
+	DESTINATION "${RELATIVE_CONFIG_INSTALL_DIR}"
+	NAMESPACE "cuda-api-wrappers::"
+	FILE cuda-api-wrappersTargets.cmake
+)
+configure_file("cmake/cuda-api-wrappersConfig.cmake.in"
+	"${PROJECT_BINARY_DIR}/cuda-api-wrappersConfig.cmake" @ONLY)
+
+install(
+	FILES "${PROJECT_BINARY_DIR}/cuda-api-wrappersConfig.cmake"
+	DESTINATION "${RELATIVE_CONFIG_INSTALL_DIR}"
+)
+
+if(EXPORT_BUILD_DIR AND NOT CMAKE_EXPORT_NO_PACKAGE_REGISTRY)
+	message("-- Exporting cuda-api-wrappers build directory to local CMake package registry.")
+
+	export(
+		EXPORT cuda-api-wrappers
+		NAMESPACE "cuda-api-wrappers::"
+		FILE "${PROJECT_BINARY_DIR}/cuda-api-wrappersTargets.cmake"
+	)
+	# Export the project build directory as a package into the local CMake package registry.
+	export(PACKAGE cuda-api-wrappers)
+	# Configure a *Config.cmake file for the export of the build directory from
+	# the template, reflecting the current build options.
+	set(SETUP_PACKAGE_CONFIG_FOR_INSTALLATION FALSE)
+
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,20 +3,22 @@
 # Notes:
 #
 # CUDA is very picky about which compiler you can use.
-# CUDA 7.x supports gcc up to version 4.9.x (and not clang);
-# CUDA 8.0 supports gcc up to version 5.4.x (and there seems
-# to be some work on getting clang to support CUDA, but it
-# looks like it's not there yet)
+# CUDA 7.x supports gcc up to version 4.9.x
+# CUDA 8.x supports gcc up to version 5.x
+# CUDA 9.x supports gcc up to version 6.x
 #
-# Also, you will need your libraries compiled to be compatible
-# with whatever CUDA-supported compiler you use.
+# (and newer versions of clang seems to support CUDA compilation as well,
+# although the API wrappers haven't been tested with those yet)
 #
-# to use a different compiler with CMake, run it as follows:
+# One way to force the use of a different compiler with CMake is to run it as follows:
 #
 # cmake -D CMAKE_C_COMPILER=/path/to/your/cc -D CMAKE_CXX_COMPILER=/path/to/your/c++ your_project_dir
 #
+# and recall also that libraries must also have been built with a compatible compiler
 #
-cmake_minimum_required(VERSION 3.1)
+
+# We need version 3.8 for native CUDA support in CMake
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
 # -----------------------------------
@@ -30,9 +32,8 @@ endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    # This is the top-level project.
-	PROJECT(cuda-api-wrappers)
+PROJECT(cuda-api-wrappers
+	LANGUAGES CUDA CXX)
 
 #	# No versioning for now
 #
@@ -40,18 +41,16 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 #	set(PROJECT_MINOR_VERSION 1)
 #	set(PROJECT_PATCH_VERSION 0)
 #	set(PROJECT_VERSION ${PROJECT_MAJOR_VERSION}.${PROJECT_MINOR_VERSION}.${PROJECT_PATCH_VERSION})
-endif()
 
 
 # ----------------------------
-# General C/C++ build settings
+# General C++ build settings
 # ----------------------------
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic" )
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-#SET(CMAKE_BUILD_TYPE distribution)
 
 include_directories( "src/" )
 
@@ -59,68 +58,40 @@ include_directories( "src/" )
 # CUDA
 # -------------
 
-find_package(CUDA 7.0 REQUIRED)
+#find_package(CUDA 7.0 REQUIRED) # Why do I to do this damn it ?!
+#include_directories( "${CUDA_TOOLKIT_INCLUDE}" )
+include_directories( ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} )
 include(HandleCUDAComputeCapability)
 
-# There is no CUDA equivalent of CMAKE_CXX_STANDARD* macros... so we're stuck with the following line:
-set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} --std=c++11)
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wall" )
+set(CMAKE_CUDA_STANDARD 11)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+set(CMAKE_CUDA_EXTENSIONS ON)
 
-set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -Xcompiler -Wall)
-if (CMAKE_BUILD_TYPE STREQUAL "Release")
-    set(CUDA_NVCC_FLAGS_RELEASE ${CUDA_NVCC_FLAGS_RELEASE} -O3 -DNDEBUG)
-elseif (CMAKE_BUILD_TYPE STREQUAL "MinSizeRel;")
-    set(CUDA_NVCC_FLAGS_DEBUG ${CUDA_NVCC_FLAGS_DEBUG} -O3 -DNDEBUG)
-elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    set(CUDA_NVCC_FLAGS_DEBUG ${CUDA_NVCC_FLAGS_DEBUG} -g --keep --generate-line-info --source-in-ptx -O3 -DNDEBUG)
-elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CUDA_NVCC_FLAGS_DEBUG ${CUDA_NVCC_FLAGS_DEBUG} -g --keep --generate-line-info --source-in-ptx)
-endif ()
-
-set(CUDA_SEPARABLE_COMPILATION ON)
-set(CUDA_PROPAGATE_HOST_FLAGS OFF)
+set(CUDA_SEPARABLE_COMPILATION ON) # Does this work with native CUDA support?
+set(CUDA_PROPAGATE_HOST_FLAGS OFF) # Does this work with native CUDA support?
 
 # This should really have been automatic...
-get_filename_component(CUDA_LIBRARY_DIR ${CUDA_CUDART_LIBRARY} DIRECTORY)
-set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} "-L${CUDA_LIBRARY_DIR}" )
+#get_filename_component(CUDA_LIBRARY_DIR ${CUDA_CUDART_LIBRARY} DIRECTORY)
+#set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} "-L${CUDA_LIBRARY_DIR}" )
 
-find_library(CUDA_NVTX_LIBRARY
-  NAMES nvToolsExt nvTools nvtoolsext nvtools nvtx NVTX
-  PATHS ${CUDA_TOOLKIT_ROOT_DIR}
-  PATH_SUFFIXES "lib64" "common/lib64" "common/lib" "lib"
-  DOC "Location of the CUDA Toolkit Extension (NVTX) library"
-  )
-mark_as_advanced(CUDA_NVTX_LIBRARY)
-set(CUDA_LIBRARIES ${CUDA_LIBRARIES} ${CUDA_NVTX_LIBRARY} ${CUDA_cudadevrt_LIBRARY})
+#set(CUDA_LIBRARIES ${CUDA_LIBRARIES} ${CUDA_NVTX_LIBRARY} ${CUDA_cudadevrt_LIBRARY})
 
 # The FindCUDA script forces the use of the libcublas library when perform device linkage;
-# but on some systems and in certain situations, its inclusion on the command line 
+# but on some systems and in certain situations, its inclusion on the command line
 # triggers various kinds of errors; so - we ensure it is empty and unused
-set(CUDA_cublas_device_LIBRARY "" CACHE FILEPATH "Path of the CUBLAS library - unused dummy value" FORCE)
+#set(CUDA_cublas_device_LIBRARY "" CACHE FILEPATH "Path of the CUBLAS library - unused dummy value" FORCE)
 
-# -----------------------
-# Miscellaneous targets
-# -----------------------
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)	
-    # This is the top-level project.
-	set_source_files_properties( tags PROPERTIES GENERATED true )
-	add_custom_target(tags
-	    COMMAND ctags --langmap=c++:+.cu.cuh.hpp  -R ./
-	    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-	add_custom_target(cclean COMMAND rm -rf CMakeCache.txt CMakeFiles/ cmake_install.cmake install_manifest.txt)
-endif()
 
 # -----------------------
 # Main target(s)
 # -----------------------
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "lib/")
-	set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "lib/")
-endif()
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "lib/")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "lib/")
 
-cuda_add_library(
+add_library(
 	cuda-api-wrappers
 	src/cuda/api/device_properties.cpp
 	src/cuda/api/profiling.cpp
@@ -147,52 +118,53 @@ cuda_add_library(
 # Examples / Tests
 # -----------------------
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+find_library(CUDART_LIBRARY cudart ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})
+link_libraries(cuda-api-wrappers ${CUDART_LIBRARY})
 
-	link_libraries(cuda-api-wrappers)
- 
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "examples/bin")
-	cuda_add_executable(vectorAdd EXCLUDE_FROM_ALL examples/modified_cuda_samples/vectorAdd/vectorAdd.cu)
-	cuda_add_executable(inlinePTX EXCLUDE_FROM_ALL examples/modified_cuda_samples/inlinePTX/inlinePTX.cu)
-	cuda_add_executable(simpleStreams EXCLUDE_FROM_ALL examples/modified_cuda_samples/simpleStreams/simpleStreams.cu)
-	cuda_add_executable(simpleIPC EXCLUDE_FROM_ALL examples/modified_cuda_samples/simpleIPC/simpleIPC.cu)
-	#----
-	add_custom_target(modified_cuda_samples)
-	add_dependencies(modified_cuda_samples vectorAdd inlinePTX simpleStreams simpleIPC)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "examples/bin")
+add_executable(vectorAdd EXCLUDE_FROM_ALL examples/modified_cuda_samples/vectorAdd/vectorAdd.cu)
+add_executable(inlinePTX EXCLUDE_FROM_ALL examples/modified_cuda_samples/inlinePTX/inlinePTX.cu)
+add_executable(simpleStreams EXCLUDE_FROM_ALL examples/modified_cuda_samples/simpleStreams/simpleStreams.cu)
+add_executable(simpleIPC EXCLUDE_FROM_ALL examples/modified_cuda_samples/simpleIPC/simpleIPC.cu)
+#----
+add_custom_target(modified_cuda_samples)
+add_dependencies(modified_cuda_samples vectorAdd inlinePTX simpleStreams simpleIPC)
 
-	add_executable(version_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/version_management.cpp)
-	target_link_libraries(version_management  ${CUDA_LIBRARIES})
-	cuda_add_executable(error_handling EXCLUDE_FROM_ALL examples/by_runtime_api_module/error_handling.cu)
-	add_executable(device_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/device_management.cpp)
-	cuda_add_executable(execution_control EXCLUDE_FROM_ALL examples/by_runtime_api_module/execution_control.cu OPTIONS -rdc true)
-	cuda_add_executable(stream_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/stream_management.cu)
-	cuda_add_executable(event_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/event_management.cu)
-	cuda_add_executable(io_compute_overlap_with_streams EXCLUDE_FROM_ALL examples/other/io_compute_overlap_with_streams.cu)
-	#----
-	add_custom_target(examples_by_runtime_api_module)
-	add_dependencies(
-		examples_by_runtime_api_module
-		version_management
-		error_handling device_management
-		execution_control
-		stream_management
-		event_management
-		io_compute_overlap_with_streams)
+add_executable(version_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/version_management.cpp)
+target_link_libraries(version_management  ${CUDA_LIBRARIES})
+add_executable(error_handling EXCLUDE_FROM_ALL examples/by_runtime_api_module/error_handling.cu)
+add_executable(device_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/device_management.cpp)
+add_executable(execution_control EXCLUDE_FROM_ALL examples/by_runtime_api_module/execution_control.cu)
+target_compile_options(execution_control PRIVATE -rdc true)
+add_executable(stream_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/stream_management.cu)
+add_executable(event_management EXCLUDE_FROM_ALL examples/by_runtime_api_module/event_management.cu)
+add_executable(io_compute_overlap_with_streams EXCLUDE_FROM_ALL examples/other/io_compute_overlap_with_streams.cu)
+#----
+add_custom_target(examples_by_runtime_api_module)
+add_dependencies(examples_by_runtime_api_module
+	version_management
+	error_handling device_management
+	execution_control
+	stream_management
+	event_management
+	io_compute_overlap_with_streams
+)
 
-	add_custom_target(examples)
-	add_dependencies(examples examples_by_runtime_api_module modified_cuda_samples)
+add_custom_target(examples)
+add_dependencies(examples examples_by_runtime_api_module modified_cuda_samples)
 
-	add_custom_target(docs 
-		COMMAND doxygen doxygen.cfg
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_custom_target(docs
+	COMMAND doxygen doxygen.cfg
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
 
-	add_dependencies(examples examples_by_runtime_api_module modified_cuda_samples)
-endif()
+add_dependencies(examples examples_by_runtime_api_module modified_cuda_samples)
 
 # -------------
 
 install(
 	TARGETS cuda-api-wrappers
+	EXPORT cuda-api-wrappers
 	ARCHIVE # For CMake, a static library is an ARCHIVE, a dynamic library is a RUNTIME
 	DESTINATION lib
 	INCLUDES DESTINATION include
@@ -200,8 +172,10 @@ install(
 )
 
 install(
+#	EXPORT cuda-api-wrappers
 	DIRECTORY src/cuda
 	DESTINATION include
 	FILES_MATCHING REGEX "\\.(h|hpp|cuh)"
 )
 
+export(EXPORT cuda-api-wrappers FILE cuda-api-wrappers.cmake)

--- a/cmake/Modules/HandleCUDAComputeCapability.cmake
+++ b/cmake/Modules/HandleCUDAComputeCapability.cmake
@@ -17,14 +17,14 @@ if (NOT CUDA_TARGET_COMPUTE_CAPABILITY)
 				set(CUDA_TARGET_COMPUTE_CAPABILITY_ $ENV{CUDA_SM})
 		endif()
 
+		execute_process(COMMAND bash -c "echo -n $(echo ${CUDA_TARGET_COMPUTE_CAPABILITY_})" OUTPUT_VARIABLE CUDA_TARGET_COMPUTE_CAPABILITY_) 
 		set(CUDA_TARGET_COMPUTE_CAPABILITY "${CUDA_TARGET_COMPUTE_CAPABILITY_}" CACHE STRING "CUDA compute capability of the (first) CUDA device on the system, in XY format (like the X.Y format but no dot); see table of features and capabilities by capability X.Y value at https://en.wikipedia.org/wiki/CUDA#Version_features_and_specifications")
-
-		execute_process(COMMAND bash -c "echo -n $(echo ${CUDA_TARGET_COMPUTE_CAPABILITY})" OUTPUT_VARIABLE CUDA_TARGET_COMPUTE_CAPABILITY) 
 		execute_process(COMMAND bash -c "echo ${CUDA_TARGET_COMPUTE_CAPABILITY} | sed 's/^\\([0-9]\\)\\([0-9]\\)/\\1.\\2/;' | xargs echo -n" OUTPUT_VARIABLE FORMATTED_COMPUTE_CAPABILITY) 
 
 		message(STATUS "CUDA device-side code will assume compute capability ${FORMATTED_COMPUTE_CAPABILITY}")
 endif()
 
+# TODO this should be set on a target base and not in a general way
 set(CUDA_GENCODE "arch=compute_${CUDA_TARGET_COMPUTE_CAPABILITY},code=compute_${CUDA_TARGET_COMPUTE_CAPABILITY}")
 set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -gencode ${CUDA_GENCODE} )
 

--- a/cmake/cuda-api-wrappersConfig.cmake.in
+++ b/cmake/cuda-api-wrappersConfig.cmake.in
@@ -1,0 +1,9 @@
+# Get the directory containing this file.
+get_filename_component(@PROJECT_NAME@_CURRENT_CONFIG_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+# Here dependencies are listed
+include(CMakeFindDependencyMacro)
+#find_dependency(cudart)
+
+# Import targets.
+include("${@PROJECT_NAME@_CURRENT_CONFIG_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/scripts/get_cuda_sm.sh
+++ b/scripts/get_cuda_sm.sh
@@ -7,7 +7,8 @@
 device_index=${1:-0}
 timestamp=$(date +%s.%N)
 gcc_binary=${CMAKE_CXX_COMPILER:-$(which c++)}
-cuda_root=${CUDA_DIR:-/usr/local/cuda}
+nvcc_default_path=$(which nvcc)
+cuda_root=${CUDA_DIR:-${nvcc_default_path:0:-4}..}
 CUDA_INCLUDE_DIRS=${CUDA_INCLUDE_DIRS:-${cuda_root}/include}
 CUDA_CUDART_LIBRARY=${CUDA_CUDART_LIBRARY:-${cuda_root}/lib64/libcudart.so}
 generated_binary="/tmp/cuda-compute-version-helper-$$-$timestamp"


### PR DESCRIPTION
* Users can now easily use this project in their CMake
  project, as a `cuda-api-wrappersConfig.cmake` file is now
  provided (`find_package(cuda-api-wrappers)`,
  `target_link_libraries(foo cuda-api-wrappers::cuda-api-wrappers)`)
* Export of build directory to local CMake package registry
  can now be turned on, to use this project without installing it
* Minor fix of automatic CUDA architecture detection script
* Compile options are now `PRIVATE` or `PUBLIC` to enhance the usage
  in other projects
* Add `ipc` sample to the build