### PR TITLE
Cmake modernization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,6 @@ install(
 	ARCHIVE DESTINATION lib
 	LIBRARY DESTINATION lib
 	INCLUDES DESTINATION include
-	CONFIGURATIONS Release RelWithDebugInfo
 )
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 include_directories( "src/" )
 
+#----------------
+# Build options
+#----------------
+
+option(EXPORT_BUILD_DIR "Enables external use without install" OFF)
+
 # -------------
 # CUDA
 # -------------
@@ -172,3 +178,17 @@ install(
 	# do not use any `find_package` call here this approach is sufficient.
 	FILE ${PROJECT_NAME}Config.cmake
 )
+
+if(EXPORT_BUILD_DIR AND NOT CMAKE_EXPORT_NO_PACKAGE_REGISTRY)
+	message("-- Exporting ${PROJECT_NAME} build directory to local CMake package registry.")
+
+	export(
+		EXPORT ${PROJECT_NAME}Export
+		NAMESPACE "${PROJECT_NAME}::"
+		# In this CMake config file no dependencies are considered. But since we
+		# do not use any `find_package` call here this approach is sufficient.
+		FILE "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+	)
+	# Export the project build directory as a package into the local CMake package registry.
+	export(PACKAGE ${PROJECT_NAME})
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,9 @@ add_library(
 
 target_include_directories(
 	${PROJECT_NAME}
-	INTERFACE "$<INSTALL_INTERFACE:include>"
-	PRIVATE   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src"
+		PUBLIC
+		"$<INSTALL_INTERFACE:include>"
+		"$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
 )
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,3 +164,12 @@ install(
 	DESTINATION include
 	FILES_MATCHING REGEX "\\.(h|hpp|cuh)"
 )
+
+install(
+	EXPORT ${PROJECT_NAME}
+	DESTINATION "share/cmake/${PROJECT_NAME}"
+	NAMESPACE "${PROJECT_NAME}::"
+	# In this CMake config file no dependencies are considered. But since we
+	# do not use any `find_package` call here this approach is sufficient.
+	FILE ${PROJECT_NAME}Config.cmake
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ add_dependencies(examples examples_by_runtime_api_module modified_cuda_samples)
 
 install(
 	TARGETS cuda-api-wrappers
-	EXPORT cuda-api-wrappers
+	EXPORT cuda-api-wrappersExport
 	RUNTIME DESTINATION bin
 	ARCHIVE DESTINATION lib
 	LIBRARY DESTINATION lib
@@ -166,7 +166,7 @@ install(
 )
 
 install(
-	EXPORT ${PROJECT_NAME}
+	EXPORT ${PROJECT_NAME}Export
 	DESTINATION "share/cmake/${PROJECT_NAME}"
 	NAMESPACE "${PROJECT_NAME}::"
 	# In this CMake config file no dependencies are considered. But since we

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,5 +165,3 @@ install(
 	DESTINATION include
 	FILES_MATCHING REGEX "\\.(h|hpp|cuh)"
 )
-
-export(EXPORT cuda-api-wrappers FILE cuda-api-wrappers.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,6 @@ install(
 )
 
 install(
-#	EXPORT cuda-api-wrappers
 	DIRECTORY src/cuda
 	DESTINATION include
 	FILES_MATCHING REGEX "\\.(h|hpp|cuh)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ add_dependencies(examples examples_by_runtime_api_module modified_cuda_samples)
 
 install(
 	TARGETS cuda-api-wrappers
-	EXPORT cuda-api-wrappersExport
+	EXPORT cuda-api-wrappers_export
 	RUNTIME DESTINATION bin
 	ARCHIVE DESTINATION lib
 	LIBRARY DESTINATION lib
@@ -171,7 +171,7 @@ install(
 )
 
 install(
-	EXPORT ${PROJECT_NAME}Export
+	EXPORT ${PROJECT_NAME}_export
 	DESTINATION "share/cmake/${PROJECT_NAME}"
 	NAMESPACE "${PROJECT_NAME}::"
 	# In this CMake config file no dependencies are considered. But since we
@@ -180,10 +180,10 @@ install(
 )
 
 if(EXPORT_BUILD_DIR AND NOT CMAKE_EXPORT_NO_PACKAGE_REGISTRY)
-	message("-- Exporting ${PROJECT_NAME} build directory to local CMake package registry.")
+	message(STATUS "Exporting ${PROJECT_NAME} build directory to local CMake package registry.")
 
 	export(
-		EXPORT ${PROJECT_NAME}Export
+		EXPORT ${PROJECT_NAME}_export
 		NAMESPACE "${PROJECT_NAME}::"
 		# In this CMake config file no dependencies are considered. But since we
 		# do not use any `find_package` call here this approach is sufficient.


### PR DESCRIPTION
Main features:

- Export of build directory (use in external projects without installing `cuda-api-wrappers`)
- Installation of build tree independent export set. This is important if `cuda-api-wrappers` is used by other CMake projects and `cuda-api-wrappers` was installed somewhere.
- Fix of library include directories

See

- https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/
- https://www.youtube.com/watch?v=rLopVhns4Zs&feature=youtu.be

This enhanced my personal work with CMake a lot.

I do not care if you merge all the commits into one commit. I just did it that way to keep the changes understandable.

https://github.com/eyalroz/cuda-api-wrappers/pull/60#issuecomment-425530835

So here is a smaller PR.