### PR TITLE
Delete Copy and Add Move for texture_view

### DIFF
--- a/src/cuda/api/texture_view.hpp
+++ b/src/cuda/api/texture_view.hpp
@@ -57,6 +57,20 @@ class texture_view {
 		throw_if_error(status, "failed creating a CUDA texture object");
     }
 
+	// texture_object is basically an owning pointer, therefor no copies.
+	texture_view(const texture_view&) = delete;
+	texture_view& operator=(const texture_view&) = delete;
+	// Without copies we would like to be able to move a texture_view.
+	texture_view(texture_view&& other)
+		:texture_object(other.texture_object)
+	{
+		other.texture_object = 0;
+	}
+	texture_view& operator=(texture_view&& other)
+	{
+		std::swap(other.texture_object,texture_object);
+		return *this;
+	}
 	~texture_view()
 	{
 		auto status = cudaDestroyTextureObject(texture_object);


### PR DESCRIPTION
Currently texture_view happily creates copies, and possible double destroy texture_object. This can be countered by deleting copy constructor and copy operator. Then it would be nice to have move constructor and move operator. But is 0 is an invalid state for an texture_object?