### PR TITLE
Work on the texture_view class - fixes #171, #172.

### DIFF
--- a/examples/other/array_management.cu
+++ b/examples/other/array_management.cu
@@ -87,7 +87,7 @@ void array_3d_example(Device& device, size_t w, size_t h, size_t d) {
 	cuda::launch(
 		kernels::from_3D_texture_to_memory_space,
 		cuda::make_launch_config(grid_dims, block_dims),
-		tv, ptr_out.get(), w, h, d);
+		tv.raw_handle(), ptr_out.get(), w, h, d);
 	device.synchronize();
 	check_output_is_iota("copy from 3D texture into (managed) global memory", ptr_out.get(), arr.size());
 
@@ -148,7 +148,7 @@ void array_2d_example(Device& device, size_t w, size_t h)
 	cuda::launch(
 		kernels::from_2D_texture_to_memory_space,
 		cuda::make_launch_config(grid_dims, block_dims),
-		tv, ptr_out.get(), w, h);
+		tv.raw_handle(), ptr_out.get(), w, h);
 	cuda::memory::copy(ptr_out.get(), arr);
 	device.synchronize();
 	print_2d_array(ptr_out.get(), w, h);

--- a/src/cuda/api/stream.hpp
+++ b/src/cuda/api/stream.hpp
@@ -505,7 +505,6 @@ public: // constructors and destructor
 			device::current::scoped_override_t<> set_device_for_this_scope(device_id_);
 			cudaStreamDestroy(id_);
 		}
-		owning = false;
 	}
 
 public: // operators


### PR DESCRIPTION
* Added: A `cuda::texture::handle_t` type
* Fixed: In `stream_t`, not bothing to mark the stream non-owning on destruction (method now identical to corresponding
* In the `texture_view` class code:

   * Deleted copy ctor and assignment operators
   * Customized move c'tor
   * Not destroying anything for non-owning bit.
   * Variable names tweaked
   * Added (out-of-class) comparison operators

* Made the `array_management.cu` not make implicit casts from `texture_view`'s to `unsigned long long int`'s.