### PR TITLE
Use memory regions

### DIFF
--- a/examples/by_runtime_api_module/unified_addressing.cpp
+++ b/examples/by_runtime_api_module/unified_addressing.cpp
@@ -37,12 +37,12 @@ int main(int argc, char **argv)
 	std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")" << std::endl;
 
 	static const size_t allocation_size { 1024 };
-	auto raw_ptr = device.memory().allocate(allocation_size);
+	auto memory_region = device.memory().allocate(allocation_size);
 
-	auto ptr = cuda::memory::pointer::wrap(raw_ptr);
+	auto ptr = cuda::memory::pointer::wrap(memory_region.start);
 
 	std::cout
-		<< "Verifying a wrapper for raw pointer " << raw_ptr
+		<< "Verifying a wrapper for raw pointer " << memory_region.start
 		<< " allocated on the CUDA device." << std::endl;
 
 	switch (ptr.attributes().memory_type()) {
@@ -59,12 +59,12 @@ int main(int argc, char **argv)
 			"Pointer incorrectly reported as associated with device ID " + std::to_string(ptr_device_id) +
 			" rather than " + std::to_string(device_id) + "\n");
 	}
-	(ptr.get() == raw_ptr) or die_("Invalid get() output");
-	if (ptr.get_for_device() != raw_ptr) {
+	(ptr.get() == memory_region.start) or die_("Invalid get() output");
+	if (ptr.get_for_device() != memory_region.start) {
 		std::stringstream ss;
 		ss
 			<< "Reported device-side address isn't the address we get from allocation: "
-			<< ptr.get_for_device() << " != " << raw_ptr;
+			<< ptr.get_for_device() << " != " << memory_region.start;
 		die_(ss.str());
 	}
 	(ptr.get_for_host() == nullptr) or die_("Unexpected non-nullptr host-side address reported");

--- a/examples/modified_cuda_samples/simpleIPC/simpleIPC.cu
+++ b/examples/modified_cuda_samples/simpleIPC/simpleIPC.cu
@@ -203,7 +203,7 @@ void runTestMultiKernel(ipcCUDA_t *s_mem, int index)
 		std::vector<cuda::event_t> events;
 		events.reserve(MAX_DEVICES * PROCESSES_PER_DEVICE - 1);
 		int* d_ptr = reinterpret_cast<int*>(
-			device.memory().allocate(DATA_BUF_SIZE * g_processCount * sizeof(int))
+			device.memory().allocate(DATA_BUF_SIZE * g_processCount * sizeof(int)).start
 		);
 		s_mem[0].memHandle = cuda::memory::ipc::export_((void *) d_ptr);
 		cuda::memory::copy((void *) d_ptr, (void *) h_refData, DATA_BUF_SIZE * sizeof(int));

--- a/examples/modified_cuda_samples/simpleStreams/simpleStreams.cu
+++ b/examples/modified_cuda_samples/simpleStreams/simpleStreams.cu
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
 	int nstreams = 4;               // number of streams for CUDA calls
 	int nreps = 10;                 // number of times each experiment is repeated
 	int n = 16 * 1024 * 1024;       // number of ints in the data set
-	int nbytes = n * sizeof(int);   // number of data bytes
+	std::size_t nbytes = n * sizeof(int);   // number of data bytes
 	dim3 threads, blocks;           // kernel launch configuration
 	float scale_factor = 1.0f;
 
@@ -309,7 +309,7 @@ int main(int argc, char **argv)
 	threads=dim3(512,1);
 	blocks=dim3(n/(nstreams*threads.x),1);
 	memset(h_a.get(), 255, nbytes);     // set host memory bits to all 1s, for testing correctness
-	cuda::memory::device::zero(d_a.get(), nbytes); // set device memory to all 0s, for testing correctness
+	cuda::memory::device::zero(cuda::memory::region_t{d_a.get(), nbytes}); // set device memory to all 0s, for testing correctness
 	start_event.record();
 
 	for (int k = 0; k < nreps; k++)

--- a/src/cuda/common/types.hpp
+++ b/src/cuda/common/types.hpp
@@ -22,6 +22,7 @@ static_assert(__cplusplus >= 201103L, "The CUDA Runtime API headers can only be 
 
 #ifndef __CUDACC__
 #include <builtin_types.h>
+#include <driver_types.h>
 #endif
 
 #include <type_traits>

--- a/src/cuda/nvtx/profiling.hpp
+++ b/src/cuda/nvtx/profiling.hpp
@@ -170,4 +170,4 @@ void name_this_thread(const std::basic_string<CharT>& name);
 
 } // namespace cuda
 
-#endif // CUDA_NVTX_WRAPPERS_PROFILING_HPP_
+#endif // CUDA_API_WRAPPERS_PROFILING_HPP_

--- a/src/cuda/runtime_api/device.hpp
+++ b/src/cuda/runtime_api/device.hpp
@@ -169,7 +169,7 @@ public:	// types
 		 * @param size_in_bytes size in bytes of the region of memory to allocate
 		 * @return a non-null (device-side) pointer to the allocated memory
 		 */
-		void* allocate(size_t size_in_bytes)
+		memory::region_t allocate(size_t size_in_bytes)
 		{
 			scoped_setter_t set_device_for_this_scope(device_id_);
 			return memory::device::detail::allocate(size_in_bytes);
@@ -198,7 +198,7 @@ public:	// types
 		 * it will be made usable on all CUDA devices on the systems.
 		 * @return the allocated pointer; never returns null (throws on failure)
 		 */
-		void* allocate_managed(
+		memory::region_t allocate_managed(
 			size_t size_in_bytes,
 			initial_visibility_t initial_visibility =
 				initial_visibility_t::to_supporters_of_concurrent_managed_access)

--- a/src/cuda/runtime_api/device.hpp
+++ b/src/cuda/runtime_api/device.hpp
@@ -18,7 +18,6 @@
 #include <cuda/common/types.hpp>
 
 #include <cuda_runtime_api.h>
-
 #include <string>
 #include <type_traits>
 

--- a/src/cuda/runtime_api/device_properties.hpp
+++ b/src/cuda/runtime_api/device_properties.hpp
@@ -150,6 +150,6 @@ struct properties_t : public cudaDeviceProp {
 } // namespace device
 } // namespace cuda
 
-#include <cuda/runtime_api/detail/device_properties.hpp>
+#include "detail/device_properties.hpp"
 
 #endif // CUDA_API_WRAPPERS_DEVICE_PROPERTIES_HPP_

--- a/src/cuda/runtime_api/memory.hpp
+++ b/src/cuda/runtime_api/memory.hpp
@@ -51,6 +51,15 @@ class stream_t;
  */
 namespace memory {
 
+struct region_t {
+	void* start;
+	size_t size_in_bytes;
+
+	size_t size() const { return size_in_bytes; }
+	void* data() const { return start; }
+	void* get() const { return start; }
+};
+
 /**
  * A memory allocation setting: Can the allocated memory be used in other
  * CUDA driver contexts (in addition to the implicit default context we
@@ -122,14 +131,9 @@ namespace mapped {
  * proper memory region abstraction, i.e. it has no size information
  */
 struct region_pair {
-
 	void* host_side;
 	void* device_side;
-	// size_t size_in_bytes; // common to both sides
-	// allocation_options properties;
-
-	// operator std::pair<void*, void*>() { return make_pair(host_side, device_side); }
-	// size_t size() { return size_in_bytes; }
+	size_t size_in_bytes; /// the allocated number of bytes, common to both sides
 };
 
 } // namespace mapped
@@ -151,7 +155,7 @@ namespace detail {
  *
  * @param num_bytes amount of memory to allocate in bytes
  */
-inline void* allocate(size_t num_bytes)
+inline region_t allocate(size_t num_bytes)
 {
 	void* allocated = nullptr;
 	// Note: the typed cudaMalloc also takes its size in bytes, apparently,
@@ -165,10 +169,10 @@ inline void* allocate(size_t num_bytes)
 		"Failed allocating " + std::to_string(num_bytes) +
 		" bytes of global memory on CUDA device " +
 		std::to_string(cuda::device::current::detail::get_id()));
-	return allocated;
+	return {allocated, num_bytes};
 }
 
-inline void* allocate(cuda::device::id_t device_id, size_t size_in_bytes)
+inline region_t allocate(cuda::device::id_t device_id, size_t size_in_bytes)
 {
 	cuda::device::current::detail::scoped_override_t<> set_device_for_this_scope(device_id);
 	return memory::device::detail::allocate(size_in_bytes);
@@ -177,13 +181,16 @@ inline void* allocate(cuda::device::id_t device_id, size_t size_in_bytes)
 } // namespace detail
 
 /**
- * Free a region of device-side memory which was allocated with @ref allocate.
+ * Free a region of device-side memory (regardless of how it was allocated)
  */
+///@{
 inline void free(void* ptr)
 {
 	auto result = cudaFree(ptr);
 	throw_if_error(result, "Freeing device memory at 0x" + cuda::detail::ptr_as_hex(ptr));
 }
+inline void free(region_t region) { free(region.start); }
+///@}
 
 /**
  * Allocate device-side memory on a CUDA device.
@@ -197,12 +204,12 @@ inline void free(void* ptr)
  * @param size_in_bytes the amount of memory to allocate
  * @return a pointer to the allocated stretch of memory (only usable on the CUDA device)
  */
-inline void* allocate(cuda::device_t device, size_t size_in_bytes);
+inline region_t allocate(cuda::device_t device, size_t size_in_bytes);
 
 namespace detail {
 struct allocator {
 	// Allocates on the current device!
-	void* operator()(size_t num_bytes) const { return detail::allocate(num_bytes); }
+	void* operator()(size_t num_bytes) const { return detail::allocate(num_bytes).start; }
 };
 struct deleter {
 	void operator()(void* ptr) const { cuda::memory::device::free(ptr); }
@@ -214,9 +221,12 @@ struct deleter {
  *
  * @note The equivalent of @ref std::memset for CUDA device-side memory
  *
+ * @param byte_value value to set the memory region to
+ */
+///@{
+/**
  * @param start starting address of the memory region to set, in a CUDA
  * device's global memory
- * @param byte_value value to set the memory region to
  * @param num_bytes size of the memory region in bytes
  */
 inline void set(void* start, int byte_value, size_t num_bytes)
@@ -226,16 +236,37 @@ inline void set(void* start, int byte_value, size_t num_bytes)
 }
 
 /**
+ * @param region a region to zero-out, in a CUDA device's global memory
+ */
+inline void set(region_t region, int byte_value)
+{
+	set(region.start, byte_value, region.size_in_bytes);
+}
+///@}
+
+
+/**
  * @brief Sets all bytes in a region of memory to 0 (zero)
- *
- * @param start starting address of the memory region to zero-out,
- * in a CUDA device's global memory
- * @param num_bytes size of the memory region in bytes
+ */
+///@{
+/**
+ * @param region a region to zero-out, in a CUDA device's global memory
  */
 inline void zero(void* start, size_t num_bytes)
 {
 	set(start, 0, num_bytes);
 }
+
+/**
+ * @param start starting address of the memory region to zero-out,
+ * in a CUDA device's global memory
+ * @param num_bytes size of the memory region in bytes
+ */
+inline void zero(region_t region)
+{
+	zero(region.start, region.size_in_bytes);
+}
+///@}
 
 /**
  * @brief Sets all bytes of a single pointed-to value to 0
@@ -257,8 +288,10 @@ inline void zero(T* ptr)
  * @note Since we assume Compute Capability >= 2.0, all devices support the
  * Unified Virtual Address Space, so the CUDA driver can determine, for each pointer,
  * where the data is located, and one does not have to specify this.
- *
- * @param destination A pointer to a memory region of size @p num_bytes, either in
+ */
+///@{
+/**
+ *  @param destination A pointer to a memory region of size @p num_bytes, either in
  * host memory or on any CUDA device's global memory
  * @param source A pointer to a a memory region of size @p num_bytes, either in
  * host memory or on any CUDA device's global memory
@@ -273,31 +306,50 @@ inline void copy(void *destination, const void *source, size_t num_bytes)
 }
 
 /**
+ *  @param destination A pointer to a memory region of size @p num_bytes, either in
+ * host memory or on any CUDA device's global memory
+ * @param source A pointer to a a memory region of size @p num_bytes, either in
+ * host memory or on any CUDA device's global memory
+ * @param num_bytes The number of bytes to copy from @p source to @p destination
+ */
+inline void copy(region_t destination, region_t source)
+{
+#ifndef NDEBUG
+	if (destination.size_in_bytes < source.size_in_bytes) {
+		throw std::logic_error("Can't copy a large region into a smaller one");
+	}
+#endif
+	auto result = cudaMemcpy(destination.start, source.start, source.size_in_bytes, cudaMemcpyDefault);
+	// TODO: Determine whether it was from host to device, device to host etc and
+	// add this information to the error string
+	throw_if_error(result, "Synchronously copying data");
+}
+///@}
+
+/**
  * @brief Sets all bytes in a region of memory to a fixed value
  *
  * @note The equivalent of @ref std::memset - for any and all CUDA-related
  * memory spaces
  *
- * @param start starting address of the memory region to set;
- * may be in host-side memory, global CUDA-device-side memory or
- * CUDA-managed memory.
+ * @param region the memory region to set; may be in host-side memory,
+ * global CUDA-device-side memory or CUDA-managed memory.
  * @param byte_value value to set the memory region to
- * @param num_bytes size of the memory region in bytes
  */
-inline void set(void* start, int byte_value, size_t num_bytes)
+inline void set(region_t region, int byte_value)
 {
-	pointer_t<void> pointer { start };
+	pointer_t<void> pointer { region.start };
 	switch ( pointer.attributes().memory_type() ) {
 	case device_memory:
 	case managed_memory:
-		memory::device::set(start, byte_value, num_bytes); break;
+		memory::device::set(region, byte_value); break;
 	case unregistered_memory:
 	case host_memory:
-		std::memset(start, byte_value, num_bytes); break;
+		std::memset(region.start, byte_value, region.size_in_bytes); break;
 	default:
 		throw runtime_error(
 			cuda::status::invalid_value,
-			"CUDA returned an invalid memory type for the pointer 0x" + cuda::detail::ptr_as_hex(start)
+			"CUDA returned an invalid memory type for the pointer 0x" + cuda::detail::ptr_as_hex(region.start)
 		);
 	}
 }
@@ -305,14 +357,12 @@ inline void set(void* start, int byte_value, size_t num_bytes)
 /**
  * @brief Sets all bytes in a region of memory to 0 (zero)
  *
- * @param start starting address of the memory region to zero-out;
- * may be in host-side memory, global CUDA-device-side memory or
- * CUDA-managed memory.
- * @param num_bytes size of the memory region in bytes
+ * @param region the memory region to zero-out; may be in host-side memory,
+ * global CUDA-device-side memory or CUDA-managed memory.
  */
-inline void zero(void* start, size_t num_bytes)
+inline void zero(region_t region)
 {
-	return set(start, 0, num_bytes);
+	return set(region, 0);
 }
 
 /**
@@ -462,8 +512,6 @@ inline void copy(T* destination, const array_t<T, NumDimensions>& source)
 	detail::copy(destination, source);
 }
 
-
-
 /**
  * Synchronously copies a single (typed) value between two memory locations.
  *
@@ -491,14 +539,18 @@ namespace detail {
  *
  * @note asynchronous version of @ref memory::copy
  *
- * @param destination A pointer to a memory region of size @p num_bytes, either in
- * host memory or on any CUDA device's global memory
- * @param source A pointer to a a memory region of size @p num_bytes, either in
- * host memory or on any CUDA device's global memory
- * @param num_bytes The number of bytes to copy from @p source to @p destination
  * @param stream_id A stream on which to enqueue the copy operation
  */
-inline void copy(void *destination, const void *source, size_t num_bytes, stream::id_t stream_id)
+
+///@{
+/**
+* @param destination A pointer to a memory region of size @p num_bytes, either in
+* host memory or on any CUDA device's global memory
+* @param source A pointer to a memory region of size at least @p num_bytes, either in
+* host memory or on any CUDA device's global memory
+* @param num_bytes number of bytes to copy from @p source
+*/
+inline void copy(void* destination, const void* source, size_t num_bytes, stream::id_t stream_id)
 {
 	auto result = cudaMemcpyAsync(destination, source, num_bytes, cudaMemcpyDefault, stream_id);
 
@@ -506,6 +558,24 @@ inline void copy(void *destination, const void *source, size_t num_bytes, stream
 	// add this information to the error string
 	throw_if_error(result, "Scheduling a memory copy on stream " + cuda::detail::ptr_as_hex(stream_id));
 }
+
+/**
+ *  @param destination a memory region of size @p num_bytes, either in
+ * host memory or on any CUDA device's global memory
+ * @param source a memory region of size @p num_bytes, either in
+ * host memory or on any CUDA device's global memory
+ * @param stream_id A stream on which to enqueue the copy operation
+ */
+inline void copy(region_t destination, region_t source, stream::id_t stream_id)
+{
+#ifndef NDEBUG
+	if (destination.size_in_bytes < source.size_in_bytes) {
+		throw std::logic_error("Can't copy a large region into a smaller one");
+	}
+#endif
+	copy(destination.start, source.start, source.size_in_bytes, stream_id);
+}
+///@}
 
 template<typename T>
 void copy(array_t<T, 3>& destination, const T* source, stream::id_t stream_id)
@@ -598,7 +668,8 @@ inline void copy_single(T& destination, const T& source, stream::id_t stream_id)
  * @param num_bytes The number of bytes to copy from @p source to @p destination
  * @param stream A stream on which to enqueue the copy operation
  */
-void copy(void *destination, const void *source, size_t num_bytes, stream_t& stream);
+void copy(region_t destination, region_t source, size_t num_bytes, stream_t& stream);
+
 
 /**
  * Asynchronously copies data from memory spaces into CUDA arrays.
@@ -653,9 +724,20 @@ inline void set(void* start, int byte_value, size_t num_bytes, stream::id_t stre
 	throw_if_error(result, "asynchronously memsetting an on-device buffer");
 }
 
+inline void set(region_t region, int byte_value, stream::id_t stream_id)
+{
+	set(region.start, byte_value, region.size_in_bytes, stream_id);
+}
+
+
 inline void zero(void* start, size_t num_bytes, stream::id_t stream_id)
 {
 	set(start, 0, num_bytes, stream_id);
+}
+
+inline void zero(region_t region, stream::id_t stream_id)
+{
+	zero(region.start, region.size_in_bytes, stream_id);
 }
 
 } // namespace detail
@@ -914,7 +996,7 @@ enum class attachment_t {
 
 namespace detail {
 
-inline void* allocate(
+inline region_t allocate(
 	size_t                num_bytes,
 	initial_visibility_t  initial_visibility = initial_visibility_t::to_all_devices)
 {
@@ -930,31 +1012,37 @@ inline void* allocate(
 	}
 	throw_if_error(status,
 		"Failed allocating " + std::to_string(num_bytes) + " bytes of managed CUDA memory");
-	return allocated;
+	return {allocated, num_bytes};
 }
 
 /**
  * Free a region of pinned host memory which was allocated with @ref allocate.
  */
+///@{
 inline void free(void* ptr)
 {
 	auto result = cudaFree(ptr);
 	throw_if_error(result, "Freeing managed memory at 0x" + cuda::detail::ptr_as_hex(ptr));
 }
+inline void free(region_t region)
+{
+	free(region.start);
+}
+///@}
 
 template <initial_visibility_t InitialVisibility = initial_visibility_t::to_all_devices>
 struct allocator {
 	// Allocates on the current device!
 	void* operator()(size_t num_bytes) const
 	{
-		return detail::allocate(num_bytes, InitialVisibility);
+		return detail::allocate(num_bytes, InitialVisibility).start;
 	}
 };
 struct deleter {
 	void operator()(void* ptr) const { cuda::memory::device::free(ptr); }
 };
 
-inline void* allocate(
+inline region_t allocate(
 	cuda::device::id_t    device_id,
 	size_t                num_bytes,
 	initial_visibility_t  initial_visibility = initial_visibility_t::to_all_devices)
@@ -977,7 +1065,7 @@ inline void* allocate(
  * runtime) or just to those devices with some hardware features to assist in
  * this task (= less overhead)?
  */
-void* allocate(
+region_t allocate(
 	cuda::device_t        device,
 	size_t                num_bytes,
 	initial_visibility_t  initial_visibility = initial_visibility_t::to_all_devices
@@ -996,20 +1084,24 @@ inline void free(void* managed_ptr)
 		+ cuda::detail::ptr_as_hex(managed_ptr));
 }
 
+inline void free(region_t managed_region)
+{
+	free(managed_region.start);
+}
+
 namespace async {
 
 namespace detail {
 
 inline void prefetch(
-	const void*         managed_ptr,
-	size_t              num_bytes,
+	region_t            region,
 	cuda::device::id_t  destination,
 	stream::id_t        stream_id)
 {
-	auto result = cudaMemPrefetchAsync(managed_ptr, num_bytes, destination, stream_id);
+	auto result = cudaMemPrefetchAsync(region.start, managed_region.size_in_bytes, destination, stream_id);
 	throw_if_error(result,
-		"Prefetching " + std::to_string(num_bytes) + " bytes of managed memory at address "
-		 + cuda::detail::ptr_as_hex(managed_ptr) + " to device " + std::to_string(destination));
+		"Prefetching " + std::to_string(managed_region.size_in_bytes) + " bytes of managed memory at address "
+		 + cuda::detail::ptr_as_hex(managed_region.start) + " to device " + std::to_string(destination));
 }
 
 } // namespace detail
@@ -1020,8 +1112,7 @@ inline void prefetch(
  * devices.
  */
 void prefetch(
-	const void*      managed_ptr,
-	size_t           num_bytes,
+	region_t         region,
 	cuda::device_t   destination,
 	cuda::stream_t&  stream);
 
@@ -1029,16 +1120,18 @@ void prefetch(
  * @brief Prefetches a region of managed memory into host memory. It can
  * later be used there without waiting for I/O from any of the CUDA devices.
  */
-inline void prefetch_to_host(
-	const void*      managed_ptr,
-	size_t           num_bytes)
+inline void prefetch_to_host(region_t managed_region)
 {
-	auto result = cudaMemPrefetchAsync(managed_ptr, num_bytes, cudaCpuDeviceId, stream::default_stream_id);
+	auto result = cudaMemPrefetchAsync(
+		managed_region.start,
+		managed_region.size_in_bytes,
+		cudaCpuDeviceId,
+		stream::default_stream_id);
 		// The stream ID will be ignored by the CUDA runtime API when this pseudo
 		// device indicator is used.
 	throw_if_error(result,
-		"Prefetching " + std::to_string(num_bytes) + " bytes of managed memory at address "
-		 + cuda::detail::ptr_as_hex(managed_ptr) + " into host memory");
+		"Prefetching " + std::to_string(managed_region.size_in_bytes) + " bytes of managed memory at address "
+		 + cuda::detail::ptr_as_hex(managed_region.start) + " into host memory");
 }
 
 } // namespace async
@@ -1082,6 +1175,7 @@ inline region_pair allocate(
 	allocation_options  options)
 {
 	region_pair allocated;
+	allocated.size_in_bytes = size_in_bytes;
 	auto flags = cudaHostAllocMapped &
 		cuda::memory::detail::make_cuda_host_alloc_flags(options);
 	// Note: the typed cudaHostAlloc also takes its size in bytes, apparently,

--- a/src/cuda/runtime_api/memory.hpp
+++ b/src/cuda/runtime_api/memory.hpp
@@ -37,6 +37,10 @@
 #include <memory>
 #include <cstring> // for std::memset
 
+#include <memory>
+#include <cstring> // for std::memset
+#include <vector>
+
 namespace cuda {
 
 ///@cond
@@ -981,6 +985,73 @@ inline void zero(T* ptr)
  */
 namespace managed {
 
+namespace detail {
+
+template <typename T>
+inline T get_scalar_range_attribute(region_t region, cudaMemRangeAttribute attribute)
+{
+	uint32_t attribute_value { 0 };
+	auto result = cudaMemRangeGetAttribute(
+		&attribute_value, sizeof(attribute_value), attribute, region.start, region.size_in_bytes);
+	throw_if_error(result,
+		"Obtaining an attribute for a managed memory range at " + cuda::detail::ptr_as_hex(region.start));
+	return static_cast<T>(attribute_value);
+}
+
+inline void set_scalar_range_attribute(region_t region, cudaMemoryAdvise advice, cuda::device::id_t device_id)
+{
+	auto result = cudaMemAdvise(region.start, region.size_in_bytes, advice, device_id);
+	throw_if_error(result,
+		"Setting an attribute for a managed memory range at " + cuda::detail::ptr_as_hex(region.start));
+}
+
+inline void set_scalar_range_attribute(region_t region, cudaMemoryAdvise attribute)
+{
+	cuda::device::id_t ignored_device_index{};
+	set_scalar_range_attribute(region, attribute, ignored_device_index);
+}
+
+} // namespace detail
+
+struct region_t : public memory::region_t {
+	using parent = memory::region_t;
+
+#if __cplusplus < 201703L
+	region_t() = default;
+	region_t(void* start, size_t size_in_bytes) : parent{start, size_in_bytes} { }
+	region_t(const region_t&) = default;
+	region_t(region_t&&) = default;
+	~region_t() = default;
+#endif
+
+	// TODO: Consider using a field proxy
+
+	bool is_read_mostly() const
+	{
+		return detail::get_scalar_range_attribute<bool>(*this, cudaMemRangeAttributeReadMostly);
+	}
+
+	void designate_read_mostly() const
+	{
+		detail::set_scalar_range_attribute(*this, cudaMemAdviseSetReadMostly);
+	}
+
+	void undesignate_read_mostly() const
+	{
+		detail::set_scalar_range_attribute(*this, cudaMemAdviseUnsetReadMostly);
+	}
+
+	device_t preferred_location() const;
+	void set_preferred_location(device_t& device) const;
+	void clear_preferred_location() const;
+
+	void advise_expected_access_by(device_t& device) const;
+	void advise_no_access_expected_by(device_t& device) const;
+
+	template <typename Allocator = std::allocator<cuda::device_t> >
+	typename std::vector<device_t, Allocator> accessors(region_t region, const Allocator& allocator = Allocator() ) const;
+};
+
 enum class initial_visibility_t {
 	to_all_devices,
 	to_supporters_of_concurrent_managed_access,
@@ -1084,10 +1155,31 @@ inline void free(void* managed_ptr)
 		+ cuda::detail::ptr_as_hex(managed_ptr));
 }
 
-inline void free(region_t managed_region)
+inline void free(region_t region)
 {
-	free(managed_region.start);
+	free(region.start);
 }
+
+namespace advice {
+
+enum device_inspecific_kind_t {
+	read_mostly = cudaMemAdviseSetReadMostly,
+};
+
+enum device_specific_kind_t {
+	preferred_location,
+	accessor,
+};
+
+inline void set(region_t region, device_inspecific_kind_t advice)
+{
+	cuda::device::id_t ignored_device_index{};
+	auto result = cudaMemAdvise(region.start, region.size_in_bytes, (cudaMemoryAdvise) advice, ignored_device_index);
+	throw_if_error(result,
+		"Setting advice on a (managed) memory region at" + cuda::detail::ptr_as_hex(region.start));
+}
+
+} // namespace advice
 
 namespace async {
 
@@ -1098,10 +1190,10 @@ inline void prefetch(
 	cuda::device::id_t  destination,
 	stream::id_t        stream_id)
 {
-	auto result = cudaMemPrefetchAsync(region.start, managed_region.size_in_bytes, destination, stream_id);
+	auto result = cudaMemPrefetchAsync(region.start, region.size_in_bytes, destination, stream_id);
 	throw_if_error(result,
-		"Prefetching " + std::to_string(managed_region.size_in_bytes) + " bytes of managed memory at address "
-		 + cuda::detail::ptr_as_hex(managed_region.start) + " to device " + std::to_string(destination));
+		"Prefetching " + std::to_string(region.size_in_bytes) + " bytes of managed memory at address "
+		 + cuda::detail::ptr_as_hex(region.start) + " to device " + std::to_string(destination));
 }
 
 } // namespace detail

--- a/src/cuda/runtime_api/multi_wrapper_impls.hpp
+++ b/src/cuda/runtime_api/multi_wrapper_impls.hpp
@@ -233,6 +233,11 @@ inline void copy(void *destination, const void *source, size_t num_bytes, stream
 	detail::copy(destination, source, num_bytes, stream.id());
 }
 
+inline void copy(region_t destination, region_t source, stream_t& stream)
+{
+	detail::copy(destination, source, stream.id());
+}
+
 template <typename T, dimensionality_t NumDimensions>
 inline void copy(array_t<T, NumDimensions>& destination, const T* source, stream_t& stream)
 {
@@ -255,7 +260,7 @@ inline void copy_single(T& destination, const T& source, stream_t& stream)
 
 namespace device {
 
-inline void* allocate(cuda::device_t device, size_t size_in_bytes)
+inline region_t allocate(cuda::device_t device, size_t size_in_bytes)
 {
 	return detail::allocate(device.id(), size_in_bytes);
 }
@@ -281,18 +286,17 @@ namespace managed {
 namespace async {
 
 inline void prefetch(
-	const void*      managed_ptr,
-	size_t           num_bytes,
+	region_t         region,
 	cuda::device_t   destination,
 	cuda::stream_t&  stream)
 {
-	detail::prefetch(managed_ptr, num_bytes, destination.id(), stream.id());
+	detail::prefetch(region, destination.id(), stream.id());
 }
 
 } // namespace async
 
 
-inline void* allocate(
+inline region_t allocate(
 	cuda::device_t        device,
 	size_t                num_bytes,
 	initial_visibility_t  initial_visibility)
@@ -380,7 +384,7 @@ kernel_t::min_grid_params_for_max_occupancy(
 	auto result = cudaOccupancyMaxPotentialBlockSizeWithFlags(
 		&min_grid_size_in_blocks, &block_size,
 		ptr_,
-		static_cast<memory::shared::size_t>(dynamic_shared_memory_size),
+		static_cast<std::size_t>(dynamic_shared_memory_size),
 		static_cast<int>(block_size_limit),
 		disable_caching_override ? cudaOccupancyDisableCachingOverride : cudaOccupancyDefault
 		);

--- a/src/cuda/runtime_api/pointer.hpp
+++ b/src/cuda/runtime_api/pointer.hpp
@@ -22,7 +22,6 @@
 #include <cuda/common/types.hpp>
 
 #include <cuda_runtime_api.h>
-
 #ifndef NDEBUG
 #include <cassert>
 #endif

--- a/src/cuda/runtime_api/stream.hpp
+++ b/src/cuda/runtime_api/stream.hpp
@@ -345,6 +345,10 @@ public: // mutators
 		 * Have the CUDA device perform an I/O operation between two specified
 		 * memory regions (on or off the actual device)
 		 *
+		 */
+
+		///@{
+		/**
 		 * @param destination destination region into which to copy. May be
 		 * anywhere in which memory can be mapped to the device's memory space (e.g.
 		 * the device's global memory, host memory or the global memory of another device)
@@ -359,6 +363,12 @@ public: // mutators
 			// http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#stream-and-event-behavior
 			memory::async::detail::copy(destination, source, num_bytes, associated_stream.id_);
 		}
+
+		void copy(memory::region_t destination, memory::region_t source)
+		{
+			memory::async::detail::copy(destination, source, associated_stream.id_);
+		}
+		///@}
 
 		/**
 		 * Set all bytes of a certain region in device memory (or unified memory,

--- a/src/cuda/runtime_api/stream.hpp
+++ b/src/cuda/runtime_api/stream.hpp
@@ -489,7 +489,9 @@ public: // mutators
 		 * @note Attachment happens asynchronously, as an operation on this stream, i.e.
 		 * the attachment goes into effect (some time after) previous scheduled actions have
 		 * concluded.
-		 *
+		 */
+		///@{
+		/**
 		 * @param managed_region_start a pointer to the beginning of the managed memory region.
 		 * This cannot be a pointer to anywhere in the middle of an allocated region - you must
 		 * pass whatever @ref cuda::memory::managed::allocate() (or `cudaMallocManaged()`)
@@ -512,6 +514,19 @@ public: // mutators
 				" on stream " + cuda::detail::ptr_as_hex(associated_stream.id_)
 				+ " on CUDA device " + std::to_string(associated_stream.device_id_));
 		}
+
+		/**
+		 * @param region the managed memory region to attach; it cannot be a sub-region -
+		 * you must pass whatever @ref cuda::memory::managed::allocate() returned.
+		 */
+		void memory_attachment(
+			memory::managed::region_t region,
+			memory::managed::attachment_t attachment = memory::managed::attachment_t::single_stream)
+		{
+			memory_attachment(region.start, attachment);
+		}
+		///@}
+
 
 		/**
 		 * Will pause all further activity on the stream until the specified event has


### PR DESCRIPTION
This changes the way we allocate memory, or rather - what we return from the `allocate()` functions: regions (pointer+size), not plain pointers.

The availability and usability of a region class allows for a straightforward wrapping of `cudaMemAdvise()` and `cudaGetMemRangeAttributes()` - as well as simplifying the interface of some of the functions which were taking an address and a number-of-bytes separately.