### PR TITLE
Added build flags to force MSVC to report correct value for __cplusplus macro, related to #237

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,12 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "lib/")
 # Our library targets
 # -------------------
 
+if(MSVC)
+    # force MSVC to define correct values for __cplusplus macro
+    string(APPEND CMAKE_CXX_FLAGS " /Zc:__cplusplus")
+    string(APPEND CMAKE_CUDA_FLAGS " -Xcompiler=\"/Zc:__cplusplus\"")
+endif()
+
 add_library(runtime-api INTERFACE) # A header-only library!
 add_library(nvtx)
 set(wrapper-libraries runtime-api nvtx)


### PR DESCRIPTION
Per default MSVC does set the value of the `__cplusplus` macro to `199711L` even when compiling with newer C++ std option specified explicitly, e.g. `/std:c++17` (see also [this blogpost](https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/)). This leads to static assertions being triggered in types.hpp causing the build to fail when compiling with MSVC.
When building with MSVC and specifying `/Zc:__cplusplus` `__cplusplus` will reflect the actual chosen C++ std version and no assertions will be hit anymore.