### PR TITLE
Fix build error when compiling with latest VS 2019

### DIFF
--- a/examples/other/io_compute_overlap_with_streams.cu
+++ b/examples/other/io_compute_overlap_with_streams.cu
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
 			num_elements);
 		stream.enqueue.copy(buffer_set.host_result.get(), buffer_set.device_result.get(), buffer_size);
 		stream.enqueue.host_function_call(
-			[k](cuda::stream_t) {
+			[k, num_kernels](cuda::stream_t) {
 				std::cout
 					<< "Stream " << k+1 << " of " << num_kernels << " has concluded all work. " << std::endl;
 			}


### PR DESCRIPTION
Building the examples with VS 2019 16.11.2, CUDA 11.4 and latest MSVC toolset compilation will fail for `io_compute_overlap_with_streams.cu`, caused by a (falsely?) reported missing capture mode for a `constexpr` variable.
This PR fixes the build error.

Issue mentioned in #237 