### PR TITLE
Fixes #345

### DIFF
--- a/.github/action-scripts/install-cuda-windows.ps1
+++ b/.github/action-scripts/install-cuda-windows.ps1
@@ -16,14 +16,14 @@
 
 # Dictionary of known cuda versions and thier download URLS, which do not follow a consistent pattern :(
 $CUDA_KNOWN_URLS = @{
-    "8.0.44" = "http://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
-    "8.0.61" = "http://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
-    "9.0.176" = "http://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
-    "9.1.85" = "http://developer.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
-    "9.2.148" = "http://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
-    "10.0.130" = "http://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
-    "10.1.105" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.105_win10_network.exe";
-    "10.1.168" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
+    "8.0.44" = "http://developer.download.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
+    "8.0.61" = "http://developer.download.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
+    "9.0.176" = "http://developer.download.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
+    "9.1.85" = "http://developer.download.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
+    "9.2.148" = "http://developer.download.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
+    "10.0.130" = "http://developer.download.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
+    "10.1.105" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.105_win10_network.exe";
+    "10.1.168" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
     "10.1.243" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
     "10.2.89" = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
     "11.0.1" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe";
@@ -36,7 +36,12 @@ $CUDA_KNOWN_URLS = @{
     "11.2.2" = "https://developer.download.nvidia.com/compute/cuda/11.2.2/network_installers/cuda_11.2.2_win10_network.exe";
     "11.3.0" = "https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe";
     "11.4.0" = "https://developer.download.nvidia.com/compute/cuda/11.4.0/network_installers/cuda_11.4.0_win10_network.exe";
-    "11.5.0" = "https://developer.download.nvidia.com/compute/cuda/11.5.0/network_installers/cuda_11.5.0_win10_network.exe"
+    "11.5.0" = "https://developer.download.nvidia.com/compute/cuda/11.5.0/network_installers/cuda_11.5.0_win10_network.exe";
+    "11.5.2" = "https://developer.download.nvidia.com/compute/cuda/11.5.2/network_installers/cuda_11.5.2_windows_network.exe";
+    "11.6.0" = "https://developer.download.nvidia.com/compute/cuda/11.6.0/network_installers/cuda_11.6.0_windows_network.exe";
+    "11.6.1" = "https://developer.download.nvidia.com/compute/cuda/11.6.1/network_installers/cuda_11.6.1_windows_network.exe";
+    "11.6.2" = "https://developer.download.nvidia.com/compute/cuda/11.6.2/network_installers/cuda_11.6.2_windows_network.exe";
+    "11.7.0" = "https://developer.download.nvidia.com/compute/cuda/11.7.0/network_installers/cuda_11.7.0_windows_network.exe"
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
@@ -132,7 +137,7 @@ if($CUDA_KNOWN_URLS.containsKey($CUDA_VERSION_FULL)){
 } else{
     # Guess what the url is given the most recent pattern (at the time of writing, 10.1)
     Write-Output "note: URL for CUDA ${$CUDA_VERSION_FULL} not known, taking an educated guess."
-    $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+    $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
 }
 $CUDA_REPO_PKG_LOCAL="cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
 

--- a/.github/workflows/cmake-build-linux.yml
+++ b/.github/workflows/cmake-build-linux.yml
@@ -34,6 +34,21 @@ jobs:
       matrix:
         include:
         - os: ubuntu-20.04
+          cuda: "11.7"
+          gcc: 10
+          shell: "bash"
+          cmake-generator: "Unix Makefiles"
+        - os: ubuntu-20.04
+          cuda: "11.6.2"
+          gcc: 10
+          shell: "bash"
+          cmake-generator: "Unix Makefiles"
+        - os: ubuntu-20.04
+          cuda: "11.6.1"
+          gcc: 10
+          shell: "bash"
+          cmake-generator: "Unix Makefiles"
+        - os: ubuntu-20.04
           cuda: "11.6"
           gcc: 10
           shell: "bash"

--- a/.github/workflows/cmake-build-windows.yml
+++ b/.github/workflows/cmake-build-windows.yml
@@ -31,6 +31,24 @@ jobs:
         include:
           # Windows2019 & VS 2019 supports 10.1+
           - os: windows-2019
+            cuda: "11.7.0"
+            visual-studio: "Visual Studio 16 2019"
+            shell: "powershell"
+            os-type: "windows"
+            cmake-platform-flag: "-A x64"
+          - os: windows-2019
+            cuda: "11.6.2"
+            visual-studio: "Visual Studio 16 2019"
+            shell: "powershell"
+            os-type: "windows"
+            cmake-platform-flag: "-A x64"
+          - os: windows-2019
+            cuda: "11.6.1"
+            visual-studio: "Visual Studio 16 2019"
+            shell: "powershell"
+            os-type: "windows"
+            cmake-platform-flag: "-A x64"
+          - os: windows-2019
             cuda: "11.6.0"
             visual-studio: "Visual Studio 16 2019"
             shell: "powershell"

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ We've all dreamed of being able to type in:
 
 	my_stream.enqueue.callback(
 		[&foo](cuda::stream_t stream, cuda::status_t status) {
-			std::cout << "Hello " << foo << " world!\n";
+			::std::cout << "Hello " << foo << " world!\n";
 		}
 	);
 

--- a/doxygen.cfg
+++ b/doxygen.cfg
@@ -339,11 +339,11 @@ TOC_INCLUDE_HEADINGS   = 5
 
 AUTOLINK_SUPPORT       = YES
 
-# If you use STL classes (i.e. std::string, std::vector, etc.) but do not want
+# If you use STL classes (i.e. ::std::string, ::std::vector, etc.) but do not want
 # to include (a tag file for) the STL sources as input, then you should set this
 # tag to YES in order to let doxygen match functions declarations and
-# definitions whose arguments contain STL classes (e.g. func(std::string);
-# versus func(std::string) {}). This also make the inheritance and collaboration
+# definitions whose arguments contain STL classes (e.g. func(::std::string);
+# versus func(::std::string) {}). This also make the inheritance and collaboration
 # diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 

--- a/examples/by_driver_api_module/context_management.cpp
+++ b/examples/by_driver_api_module/context_management.cpp
@@ -14,19 +14,19 @@ void test_context(
 	bool is_primary,
 	cuda::device::id_t device_id)
 {
-	std::cout << "Testing " << (is_primary ? "" : "non-") << "primary context " << context << '\n';
+	::std::cout << "Testing " << (is_primary ? "" : "non-") << "primary context " << context << '\n';
 	if (context.device_id() != device_id) {
 		die_("The device's primary context's reported ID and the device wrapper's ID differ: "
-			+ std::to_string(context.device_id()) + " !=" +  std::to_string(device_id));
+			+ ::std::to_string(context.device_id()) + " !=" +  ::std::to_string(device_id));
 	}
 
 	if (context.device().id() != device_id) {
 		die_("The context's associated device's ID is not the same as that of the device for which we obtained the context: "
-			+ std::to_string(context.device().id()) + " !=" +  std::to_string(device_id) );
+			+ ::std::to_string(context.device().id()) + " !=" +  ::std::to_string(device_id) );
 	}
 
 	if (context.is_primary() != is_primary) {
-		die_(std::string("The ") + (is_primary ? "" : "non-") + "primary context " + std::to_string(context)
+		die_(::std::string("The ") + (is_primary ? "" : "non-") + "primary context " + ::std::to_string(context)
 			+ " \"believes\" it is " + (is_primary ? "not " : "") + "primary.");
 	}
 
@@ -36,7 +36,7 @@ void test_context(
 	// ----------------------------------------------------------------
 
 	auto cache_preference = context.cache_preference();
-	std::cout << "The cache preference for context " << context << " is: " << cache_preference << ".\n";
+	::std::cout << "The cache preference for context " << context << " is: " << cache_preference << ".\n";
 
 	auto new_cache_preference =
 		cache_preference == cuda::multiprocessor_cache_preference_t::prefer_l1_over_shared_memory ?
@@ -45,7 +45,7 @@ void test_context(
 	context.set_cache_preference(new_cache_preference);
 	cache_preference = context.cache_preference();
 	assert_(cache_preference == new_cache_preference);
-	std::cout << "The cache preference for context " << context << " has now been set to: " << new_cache_preference << ".\n";
+	::std::cout << "The cache preference for context " << context << " has now been set to: " << new_cache_preference << ".\n";
 
 	auto shared_mem_bank_size = context.shared_memory_bank_size();
 	shared_mem_bank_size =
@@ -54,13 +54,13 @@ void test_context(
 	context.set_shared_memory_bank_size(shared_mem_bank_size);
 	auto stream_priority_range = context.stream_priority_range();
 	if (stream_priority_range.is_trivial()) {
-		std::cout << "Context " << context <<  " does not support stream priorities. "
+		::std::cout << "Context " << context <<  " does not support stream priorities. "
 			"All streams will have the same (default) priority.\n";
 	}
 	else {
-		std::cout << "Streams in context " << context << " have priorities between "
+		::std::cout << "Streams in context " << context << " have priorities between "
 			<< stream_priority_range.least << " (highest numeric value, least prioritized) and "
-			<< std::to_string(stream_priority_range.greatest) << "(lowest numeric values, most prioritized).\n";
+			<< ::std::to_string(stream_priority_range.greatest) << "(lowest numeric values, most prioritized).\n";
 		assert(stream_priority_range.least > stream_priority_range.greatest);
 	}
 
@@ -68,7 +68,7 @@ void test_context(
 	// --------------------
 
 	auto printf_fifo_size = context.get_limit(CU_LIMIT_PRINTF_FIFO_SIZE);
-	std::cout << "The printf FIFO size for context " << context << " is " << printf_fifo_size << ".\n";
+	::std::cout << "The printf FIFO size for context " << context << " is " << printf_fifo_size << ".\n";
 	decltype(printf_fifo_size) new_printf_fifo_size =
 		(printf_fifo_size <= 1024) ?  2 * printf_fifo_size : printf_fifo_size - 512;
 	context.set_limit(CU_LIMIT_PRINTF_FIFO_SIZE, new_printf_fifo_size);
@@ -78,10 +78,10 @@ void test_context(
 	// Flags - yes, yet another kind of attribute/property
 	// ----------------------------------------------------
 
-	std::cout << "Context " << context << " uses a"
+	::std::cout << "Context " << context << " uses a"
 		<< (context.synch_scheduling_policy() ? " synchronous" : "n asynchronous")
 		<< " scheduling policy.\n";
-	std::cout << "Context " << context << " is set to "
+	::std::cout << "Context " << context << " is set to "
 		<< (context.keeping_larger_local_mem_after_resize() ? "keep" : "discard")
 		<< " shared memory allocation after launch.\n";
 	// TODO: Change the settings as well obtaining them
@@ -114,11 +114,11 @@ void current_context_manipulation(
 
 	auto context_3 = cuda::context::create_and_push(device);
 
-//	std::cout << "Contexts:\n";
-//	std::cout << "context_0: " << context_0 << '\n';
-//	std::cout << "context_1: " << context_1 << '\n';
-//	std::cout << "context_2: " << context_2 << '\n';
-//	std::cout << "context_3: " << context_3 << '\n';
+//	::std::cout << "Contexts:\n";
+//	::std::cout << "context_0: " << context_0 << '\n';
+//	::std::cout << "context_1: " << context_1 << '\n';
+//	::std::cout << "context_2: " << context_2 << '\n';
+//	::std::cout << "context_3: " << context_3 << '\n';
 
 	{
 		cuda::context::current::scoped_override_t context_for_this_block { context_3 };
@@ -143,15 +143,15 @@ int main(int argc, char **argv)
 
 	// Being very cavalier about our command-line arguments here...
 	cuda::device::id_t device_id =  (argc > 1) ?
-		std::stoi(argv[1]) : cuda::device::default_device_id;
+		::std::stoi(argv[1]) : cuda::device::default_device_id;
 
 	if (cuda::device::count() <= device_id) {
-		die_("No CUDA device with ID " + std::to_string(device_id));
+		die_("No CUDA device with ID " + ::std::to_string(device_id));
 	}
 
 	auto device = cuda::device::get(device_id);
 
-	std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")\n";
+	::std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")\n";
 
 //	report_context_stack("Before anything is done");
 	auto pc = device.primary_context();
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
 	{
 		auto popped = cuda::context::current::pop();
 		if (popped != pc) {
-			die_("After pushing context " + std::to_string(pc) + " and popping it - the pop result is a different context, " + std::to_string(popped));
+			die_("After pushing context " + ::std::to_string(pc) + " and popping it - the pop result is a different context, " + ::std::to_string(popped));
 		}
 	}
 
@@ -174,18 +174,18 @@ int main(int argc, char **argv)
 	test_context(created_context, isnt_primary, device_id);
 	current_context_manipulation(device, pc, created_context);
 
-	std::cout << std::endl;
+	::std::cout << ::std::endl;
 //	report_context_stack("After current_context_manipulation");
 	cuda::context::current::push(created_context);
 	cuda::context::current::push(created_context);
 	// We should have 3 copies of created_context on the stack at this point, and nothing else
 	cudaSetDevice(device_id);
-//	report_context_stack("After cudaSetDevice " + std::to_string(device_id));
+//	report_context_stack("After cudaSetDevice " + ::std::to_string(device_id));
 	// We should have the primary context of the device
 
 
 	device.synchronize();
 	device.reset();
 
-	std::cout << "\nSUCCESS\n";
+	::std::cout << "\nSUCCESS\n";
 }

--- a/examples/by_runtime_api_module/device_management.cpp
+++ b/examples/by_runtime_api_module/device_management.cpp
@@ -24,16 +24,16 @@ void basics(cuda::device::id_t device_id)
 	// Being very cavalier about our command-line arguments here...
 
 	if (cuda::device::count() <= device_id) {
-		die_("No CUDA device with ID " + std::to_string(device_id));
+		die_("No CUDA device with ID " + ::std::to_string(device_id));
 	}
 
 	auto device = cuda::device::get(device_id);
 
-	std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")\n";
+	::std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")\n";
 
 	if (device.id() != device_id) {
 		die_("The device's reported ID and the ID for which we created the device differ: "
-		+ std::to_string(device.id()) + " !=" +  std::to_string(device_id));
+		+ ::std::to_string(device.id()) + " !=" +  ::std::to_string(device_id));
 	}
 }
 
@@ -42,7 +42,7 @@ void attributes_and_properties()
 	auto device = cuda::device::current::get();
 
 	auto max_registers_per_block = device.get_attribute(CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK);
-	std::cout
+	::std::cout
 	<< "Maximum number of registers per block on this device: "
 	<< max_registers_per_block << "\n";
 	assert_(device.properties().regsPerBlock == max_registers_per_block);
@@ -53,7 +53,7 @@ void pci_bus_id()
 	auto device = cuda::device::current::get();
 
 	auto pci_id = device.pci_id();
-	std::string pci_id_str(pci_id);
+	::std::string pci_id_str(pci_id);
 
 	cuda::outstanding_error::ensure_none();
 
@@ -70,14 +70,14 @@ void global_memory()
 	auto total_memory = device_global_mem.amount_total();
 	auto free_memory = device_global_mem.amount_total();
 
-	std::cout 
-		<< "Device " << std::to_string(device.id()) << " reports it has "
+	::std::cout
+		<< "Device " << ::std::to_string(device.id()) << " reports it has "
 		<< free_memory << " bytes free out of " << total_memory << " bytes total global memory "
 		<< "(" << (total_memory - free_memory) << " bytes used).\n";
 
     if (device != device.memory().associated_device()) {
         die_("The device's reported ID and the device's memory object's reported devices differ: "
-        + std::to_string(device.id()) + " !=" +  std::to_string(device.memory().associated_device().id()));
+        + ::std::to_string(device.id()) + " !=" +  ::std::to_string(device.memory().associated_device().id()));
     }
 
 	assert_(free_memory <= total_memory);
@@ -90,12 +90,12 @@ void shared_memory()
 {
 	auto device = cuda::device::current::get();
 //	auto primary_context = device.primary_context();
-//	report_context_stack("After getting the current device (which is " + std::to_string(device.id()) + ')');
+//	report_context_stack("After getting the current device (which is " + ::std::to_string(device.id()) + ')');
 
 	auto reported_cache_preference = device.cache_preference();
-	std::cout << "The cache preference for device " << device.id() << " is: \""	<<  reported_cache_preference << "\".\n";
+	::std::cout << "The cache preference for device " << device.id() << " is: \""	<<  reported_cache_preference << "\".\n";
 
-//	report_context_stack("After getting the cache preference for device " + std::to_string(device.id()));
+//	report_context_stack("After getting the cache preference for device " + ::std::to_string(device.id()));
 
 	auto applied_cache_preference =
 		reported_cache_preference == cuda::multiprocessor_cache_preference_t::prefer_l1_over_shared_memory ?
@@ -106,21 +106,21 @@ void shared_memory()
 //	report_context_stack("After setting cache pref");
 	reported_cache_preference = device.cache_preference();
 	if (reported_cache_preference != applied_cache_preference) {
-		std::cerr << "After setting cache preference to \""
+		::std::cerr << "After setting cache preference to \""
 				  << applied_cache_preference
 				  << "\", the reported cache preference for device " << device.id() << " is: \""
-				  << reported_cache_preference << "\"." << std::endl;
+				  << reported_cache_preference << "\"." << ::std::endl;
 		assert_(reported_cache_preference == applied_cache_preference);
 	}
 
-	std::string bank_size_names[] = {
+	::std::string bank_size_names[] = {
 		"default", "4 bytes", "8 bytes"
 	};
 
 
 	auto reported_shared_mem_bank_size = device.shared_memory_bank_size();
-	std::cout << "The reported shared memory bank size for device " << device.id() << " is: "
-			  << bank_size_names[reported_shared_mem_bank_size] << '.' << std::endl;
+	::std::cout << "The reported shared memory bank size for device " << device.id() << " is: "
+			  << bank_size_names[reported_shared_mem_bank_size] << '.' << ::std::endl;
 	auto applied_shared_mem_bank_size =
 		(reported_shared_mem_bank_size == CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE) ?
 		CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE : CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE;
@@ -131,9 +131,9 @@ void shared_memory()
 
 //	reported_shared_mem_bank_size = device.shared_memory_bank_size();
 //	if (reported_shared_mem_bank_size != applied_shared_mem_bank_size) {
-//		std::cerr << "After setting shared memory bank size to " << applied_shared_mem_bank_size
+//		::std::cerr << "After setting shared memory bank size to " << applied_shared_mem_bank_size
 //				  << ", the reported shared memory bank size for device " << device.id() << " is: "
-//				  << reported_shared_mem_bank_size << '.' << std::endl;
+//				  << reported_shared_mem_bank_size << '.' << ::std::endl;
 //	}
 }
 
@@ -143,12 +143,12 @@ void stream_priority_range()
 
 	auto stream_priority_range = device.stream_priority_range();
 	if (stream_priority_range.is_trivial()) {
-		std::cout << "Device " << device.id() << " does not support stream priorities. "
+		::std::cout << "Device " << device.id() << " does not support stream priorities. "
 												 "All streams will have the same (default) priority.\n";
 	}
 	else {
-		std::cout << "Streams on device " << device.id() << " have priorities between "
-		<< std::to_string(stream_priority_range.greatest) << " (lowest value, most prioritized) and "
+		::std::cout << "Streams on device " << device.id() << " have priorities between "
+		<< ::std::to_string(stream_priority_range.greatest) << " (lowest value, most prioritized) and "
 		<< stream_priority_range.least << " (highest value, least prioritized)\n";
 		assert_(stream_priority_range.least > stream_priority_range.greatest);
 	}
@@ -159,7 +159,7 @@ void limits()
 	auto device = cuda::device::current::get();
 
 	auto printf_fifo_size = device.get_limit(CU_LIMIT_PRINTF_FIFO_SIZE);
-	std::cout << "The printf FIFO size for device " << device.id() << " is " << printf_fifo_size << ".\n";
+	::std::cout << "The printf FIFO size for device " << device.id() << " is " << printf_fifo_size << ".\n";
 	decltype(printf_fifo_size) new_printf_fifo_size =
 		(printf_fifo_size <= 1024) ?  2 * printf_fifo_size : printf_fifo_size - 512;
 	device.set_limit(CU_LIMIT_PRINTF_FIFO_SIZE, new_printf_fifo_size);
@@ -172,16 +172,16 @@ void flags()
 {
 	auto device = cuda::device::current::get() ;
 
-	std::cout << "Device " << device.id() << " uses a"
+	::std::cout << "Device " << device.id() << " uses a"
 	<< (device.synch_scheduling_policy() ? " synchronous" : "n asynchronous")
 	<< " scheduling policy.\n";
-	std::cout << "Device " << device.id() << " is set to "
+	::std::cout << "Device " << device.id() << " is set to "
 	<< (device.keeping_larger_local_mem_after_resize() ? "keeps" : "discards")
 	<< " shared memory allocation after launch.\n";
 	// TODO: Change the settings as well obtaining them
 }
 
-void peer_to_peer(std::pair<cuda::device::id_t,cuda::device::id_t> peer_ids)
+void peer_to_peer(::std::pair<cuda::device::id_t,cuda::device::id_t> peer_ids)
 {
 	// Assumes at least two devices are available
 
@@ -191,7 +191,7 @@ void peer_to_peer(std::pair<cuda::device::id_t,cuda::device::id_t> peer_ids)
 	if (device.can_access(peer)) {
 		auto atomics_supported_over_link = cuda::device::peer_to_peer::get_attribute(
 			cuda::device::peer_to_peer::native_atomics_support, device, peer);
-		std::cout
+		::std::cout
 		<< "Native atomics are " << (atomics_supported_over_link ? "" : "not ")
 		<< "supported over the link from device " << device.id()
 		<< " to device " << peer.id() << ".\n";
@@ -220,8 +220,8 @@ void current_device_manipulation()
 	try {
 		cuda::device::current::detail_::set(device_count);
 		die_("Should not have been able to set the current device to "
-		+ std::to_string(device_count) + " since that's the device count, and "
-		+ "the maximum valid ID should be " + std::to_string(device_count - 1)
+		+ ::std::to_string(device_count) + " since that's the device count, and "
+		+ "the maximum valid ID should be " + ::std::to_string(device_count - 1)
 		+ " (one less)");
 	}
 	catch(cuda::runtime_error& e) {
@@ -238,13 +238,13 @@ void current_device_manipulation()
 
 	auto devices = cuda::devices();
 	assert_(devices.size() == cuda::device::count());
-	std::cout << "There are " << devices.size() << " 'elements' in devices().\n";
-	std::cout << "Let's count the device IDs... ";
+	::std::cout << "There are " << devices.size() << " 'elements' in devices().\n";
+	::std::cout << "Let's count the device IDs... ";
 	for(auto device : cuda::devices()) {
-		std::cout << (int) device.id() << ' ';
+		::std::cout << (int) device.id() << ' ';
 		device.synchronize();
 	}
-	std::cout << '\n';
+	::std::cout << '\n';
 }
 
 } // namespace tests
@@ -257,7 +257,7 @@ int main(int argc, char **argv)
 		die_("No CUDA devices on this system");
 	}
 	cuda::device::id_t device_id =  (argc > 1) ?
-		std::stoi(argv[1]) : cuda::device::default_device_id;
+		::std::stoi(argv[1]) : cuda::device::default_device_id;
 
 	// Being very cavalier about our command-line arguments here...
 
@@ -271,7 +271,7 @@ int main(int argc, char **argv)
 
 	if (cuda::devices().size() > 1) {
 		auto peer_id = (argc > 2) ?
-			std::stoi(argv[2]) : (cuda::device::current::get().id() + 1) % cuda::device::count();
+			::std::stoi(argv[2]) : (cuda::device::current::get().id() + 1) % cuda::device::count();
 
 		tests::peer_to_peer({device_id, peer_id});
 		tests::current_device_manipulation();
@@ -282,6 +282,6 @@ int main(int argc, char **argv)
 		device.reset();
 	}
 
-	std::cout << "\nSUCCESS\n";
+	::std::cout << "\nSUCCESS\n";
 	return EXIT_SUCCESS;
 }

--- a/examples/by_runtime_api_module/error_handling.cu
+++ b/examples/by_runtime_api_module/error_handling.cu
@@ -7,9 +7,9 @@
  */
 #include "../common.hpp"
 
-using std::cout;
-using std::cerr;
-using std::flush;
+using ::std::cout;
+using ::std::cerr;
+using ::std::flush;
 
 int main(int, char **)
 {
@@ -32,6 +32,6 @@ int main(int, char **)
 		die_("An error was outstanding, despite our not having committed any 'sticky' errors)");
 	}
 
-	std::cout << "SUCCESS\n";
+	::std::cout << "SUCCESS\n";
 	return EXIT_SUCCESS;
 }

--- a/examples/by_runtime_api_module/event_management.cu
+++ b/examples/by_runtime_api_module/event_management.cu
@@ -20,13 +20,13 @@ template <size_t N>
 poor_mans_array<char, N> message(const char* message_str)
 {
 	poor_mans_array<char, N> a;
-	assert(std::strlen(message_str) < N);
-	std::strcpy(a.data, message_str);
+	assert(::std::strlen(message_str) < N);
+	::std::strcpy(a.data, message_str);
 	return a;
 }
 
 template <size_t N>
-poor_mans_array<char, N> message(const std::string& message_str)
+poor_mans_array<char, N> message(const ::std::string& message_str)
 {
 	return message<N>(message_str.c_str());
 }
@@ -47,11 +47,11 @@ __global__ void increment(char* data, size_t length)
 }
 
 inline void report_occurrence(
-	const std::string& prefix_message,
+	const ::std::string& prefix_message,
 	const cuda::event_t& e1,
 	const cuda::event_t& e2)
 {
-	std::cout
+	::std::cout
 		<< prefix_message << ": "
 		<< "Event 1 has " << (e1.has_occurred() ? "" : "not ") << "occurred; "
 		<< "event 2 has " << (e2.has_occurred() ? "" : "not ") << "occurred.\n";
@@ -67,10 +67,10 @@ int main(int argc, char **argv)
 	static constexpr size_t N = 40;
 
 	// Being very cavalier about our command-line arguments here...
-	auto device_id =  (argc > 1) ? std::stoi(argv[1]) : cuda::device::default_device_id;
+	auto device_id =  (argc > 1) ? ::std::stoi(argv[1]) : cuda::device::default_device_id;
 	auto device = cuda::device::get(device_id);
 
-	std::cout << "Working with CUDA device " << device.name() << " (having ID " << device.id() << ")\n";
+	::std::cout << "Working with CUDA device " << device.name() << " (having ID " << device.id() << ")\n";
 
 	// Everything else - Enqueueing kernels, events, callbacks
 	// and memory attachments, recording and waiting on events
@@ -124,7 +124,7 @@ int main(int argc, char **argv)
 
 	try {
 		cuda::event::time_elapsed_between(event_1, event_2);
-		std::cerr << "Attempting to obtain the elapsed time between two events on a"
+		::std::cerr << "Attempting to obtain the elapsed time between two events on a"
 			"stream which does not auto-sync with the default stream and has not been "
 			"synchronized should fail - but it didn't\n";
 		exit(EXIT_FAILURE);
@@ -135,13 +135,13 @@ int main(int argc, char **argv)
 	}
 	event_2.synchronize();
 	report_occurrence("After synchronizing on event_2, but before synchronizing on the stream", event_1, event_2);
-	std::cout
+	::std::cout
 		<< cuda::event::time_elapsed_between(event_1, event_2).count() << " msec have elapsed, "
 		<< "executing the second kernel (\"increment\") on a buffer of " << buffer_size
 		<< " chars and triggering two callbacks.\n";
 	// ... and this should make the third kernel execute
 	stream.synchronize();
 
-	std::cout << "\nSUCCESS\n";
+	::std::cout << "\nSUCCESS\n";
 	return EXIT_SUCCESS;
 }

--- a/examples/by_runtime_api_module/execution_control.cu
+++ b/examples/by_runtime_api_module/execution_control.cu
@@ -55,25 +55,25 @@ int main(int argc, char **argv)
 
 	// Being very cavalier about our command-line arguments here...
 	cuda::device::id_t device_id =  (argc > 1) ?
-		std::stoi(argv[1]) : cuda::device::default_device_id;
+		::std::stoi(argv[1]) : cuda::device::default_device_id;
 
 	if (cuda::device::count() <= device_id) {
-		die_("No CUDA device with ID " + std::to_string(device_id));
+		die_("No CUDA device with ID " + ::std::to_string(device_id));
 	}
 
 	auto device = cuda::device::get(device_id).make_current();
-	std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")\n";
+	::std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")\n";
 	auto kernel = cuda::kernel::get(device, kernel_function);
 
 	// ------------------------------------------
 	//  Attributes without a specific API call
 	// ------------------------------------------
 
-	std::cout
+	::std::cout
 		<< "The PTX version used in compiling device function " << kernel_name
 		<< " is " << kernel.ptx_version() << ".\n";
 
-	std::string cache_preference_names[] = {
+	::std::string cache_preference_names[] = {
 		"No preference",
 		"Equal L1 and shared memory",
 		"Prefer shared memory over L1",
@@ -101,20 +101,20 @@ int main(int argc, char **argv)
 
 	const int bar = 123;
 	const unsigned num_blocks = 3;
-	std::cout << "Getting kernel attribute CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK" << std::endl;
+	::std::cout << "Getting kernel attribute CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK" << ::std::endl;
 	auto max_threads_per_block = kernel.get_attribute(CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK);
 	auto launch_config = cuda::make_launch_config(num_blocks, max_threads_per_block);
-	std::cout
+	::std::cout
 		<< "Launching kernel " << kernel_name
-		<< " with " << num_blocks << " blocks, using cuda::launch()" << std::endl;
+		<< " with " << num_blocks << " blocks, using cuda::launch()" << ::std::endl;
 	{
 		// Copy and move construction and assignment of launch configurations
 		auto launch_config_2 = cuda::make_launch_config(2, 2, 2);
 		auto launch_config_3 = cuda::make_launch_config(3, 3, 3);
 		[[maybe_unused]] cuda::launch_configuration_t launch_config_4{launch_config};
 		launch_config_4 = launch_config_2;
-		launch_config_4 = std::move(launch_config_3);
-		[[maybe_unused]] cuda::launch_configuration_t launch_config_5{std::move(launch_config_2)};
+		launch_config_4 = ::std::move(launch_config_3);
+		[[maybe_unused]] cuda::launch_configuration_t launch_config_5{::std::move(launch_config_2)};
     // In case the `[[maybe_unused]]` attribute is ignored, let's try to trick the compiler
     // into thinking we're actually using launch_config_4.
     launch_config_4.dimensions == launch_config.dimensions;
@@ -124,10 +124,10 @@ int main(int argc, char **argv)
 	cuda::device::current::get().synchronize();
 
 	// Let's do the same, but when the kernel is wrapped in a kernel_t
-	std::cout
+	::std::cout
 		<< "Launching kernel " << kernel_name
 		<< " wrapped in a kernel_t structure,"
-		<< " with " << num_blocks << " blocks, using cuda::launch()\n" << std::flush;
+		<< " with " << num_blocks << " blocks, using cuda::launch()\n" << ::std::flush;
 
 	cuda::launch(kernel, launch_config, bar);
 	cuda::device::current::get().synchronize();
@@ -135,9 +135,9 @@ int main(int argc, char **argv)
 	// But there's more than one way to launch! we can also do
 	// it via the device proxy, using the default stream:
 
-	std::cout
+	::std::cout
 		<< "Launching kernel " << kernel_name
-		<< " with " << num_blocks << " blocks, using device.launch()\n" << std::flush;
+		<< " with " << num_blocks << " blocks, using device.launch()\n" << ::std::flush;
 	device.launch(kernel_function, launch_config, bar);
 	device.synchronize();
 
@@ -145,9 +145,9 @@ int main(int argc, char **argv)
 
 	auto stream = cuda::device::current::get().create_stream(cuda::stream::async);
 
-	std::cout
+	::std::cout
 		<< "Launching kernel " << kernel_name
-		<< " with " << num_blocks << " blocks, using stream.launch()\n" << std::flush;
+		<< " with " << num_blocks << " blocks, using stream.launch()\n" << ::std::flush;
 	stream.enqueue.kernel_launch(kernel, launch_config, bar);
 	stream.synchronize();
 
@@ -159,28 +159,28 @@ int main(int argc, char **argv)
 			auto cooperative_kernel_name = "grid_cooperating_foo";
 			auto cooperative_config = launch_config;
 			cooperative_config.block_cooperation = true;
-			std::cout
+			::std::cout
 			<< "Launching kernel" << cooperative_kernel_name
 				<< " with " << num_blocks << " blocks, cooperatively, using stream.launch()\n"
-				<< "(but note this does not actually check that cooperation takes place).\n" << std::flush;
+				<< "(but note this does not actually check that cooperation takes place).\n" << ::std::flush;
 			stream.enqueue.kernel_launch(cooperative_kernel_function, cooperative_config, bar);
 			stream.synchronize();
 
 			// Same, but using cuda::enqueue_launch
-			std::cout
+			::std::cout
 				<< "Launching kernel " << cooperative_kernel_name
 				<< " wrapped in a kernel_t structure,"
 				<< " with " << num_blocks << " blocks, using cuda::enqueue_launch(),"
 				<< " and allowing thread block cooperation\n"
-				<< "(but note this does not actually check that cooperation takes place).\n" << std::flush;
+				<< "(but note this does not actually check that cooperation takes place).\n" << ::std::flush;
 
 			cuda::enqueue_launch(cooperative_kernel_function, stream, cooperative_config, bar);
 			cuda::device::current::get().synchronize();
 		}
 		else {
-			std::cout
+			::std::cout
 				<< "Skipping launch of kernel" << kernel_name
-				<< ", since our CUDA device doesn't support cooperative launches.\n" << std::flush;
+				<< ", since our CUDA device doesn't support cooperative launches.\n" << ::std::flush;
 		}
 
 	}
@@ -196,12 +196,12 @@ int main(int argc, char **argv)
 	auto non_cooperative_kernel = cuda::kernel::get(device, kernel_function);
 	auto non_cooperative_config = launch_config;
 	non_cooperative_config.block_cooperation = true;
-	std::cout
+	::std::cout
 		<< "Launching kernel " << kernel_name << " with "
-		<< num_blocks << " blocks, un-cooperatively, using stream.launch()\n" << std::flush;
+		<< num_blocks << " blocks, un-cooperatively, using stream.launch()\n" << ::std::flush;
 	stream.enqueue.kernel_launch(non_cooperative_kernel, non_cooperative_config, bar);
 	stream.synchronize();
 
-	std::cout << "\nSUCCESS\n";
+	::std::cout << "\nSUCCESS\n";
 	return EXIT_SUCCESS;
 }

--- a/examples/by_runtime_api_module/ipc.cpp
+++ b/examples/by_runtime_api_module/ipc.cpp
@@ -28,9 +28,9 @@
 #include <cuda/api/pci_id.hpp>
 
 
-[[noreturn]] void die_(const std::string& message)
+[[noreturn]] void die_(const ::std::string& message)
 {
-	std::cerr << message << "\n";
+	::std::cerr << message << "\n";
 	exit(EXIT_FAILURE);
 }
 
@@ -38,10 +38,10 @@ int main(int argc, char **argv)
 {
 	// Being very cavalier about our command-line arguments here...
 	cuda::device::id_t device_id =  (argc > 1) ?
-		std::stoi(argv[1]) : cuda::device::default_device_id;
+		::std::stoi(argv[1]) : cuda::device::default_device_id;
 	auto device = cuda::device::get(device_id);
 
-	std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")\n";
+	::std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")\n";
 
 	// fork process
 
@@ -69,6 +69,6 @@ int main(int argc, char **argv)
 
 	// print other kernel's output
 
-	std::cout << "\nSUCCESS\n";
+	::std::cout << "\nSUCCESS\n";
 	return EXIT_SUCCESS;
 }

--- a/examples/by_runtime_api_module/stream_management.cu
+++ b/examples/by_runtime_api_module/stream_management.cu
@@ -7,7 +7,7 @@
  */
 #include "../common.hpp"
 
-using std::printf;
+using ::std::printf;
 
 template <typename T, size_t N>
 struct poor_mans_array {
@@ -22,13 +22,13 @@ template <size_t N>
 poor_mans_array<char, N> message(const char* message_str)
 {
 	poor_mans_array<char, N> a;
-	assert(std::strlen(message_str) < N);
-	std::strcpy(a.data, message_str);
+	assert(::std::strlen(message_str) < N);
+	::std::strcpy(a.data, message_str);
 	return a;
 }
 
 template <size_t N>
-poor_mans_array<char, N> message(const std::string& message_str)
+poor_mans_array<char, N> message(const ::std::string& message_str)
 {
 	return message<N>(message_str.c_str());
 }
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
 
 	// Being very cavalier about our command-line arguments here...
 	cuda::device::id_t device_id =  (argc > 1) ?
-		std::stoi(argv[1]) : cuda::device::default_device_id;
+		::std::stoi(argv[1]) : cuda::device::default_device_id;
 
 	if (cuda::device::count() == 0) {
 		die_("No CUDA devices on this system");
@@ -89,13 +89,13 @@ int main(int argc, char **argv)
 
 	auto device = cuda::device::get(device_id).make_current();
 
-	std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")\n";
+	::std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")\n";
 
 	// Stream creation and destruction, stream flags
 	//------------------------------------------------
 	{
 		auto stream = cuda::device::current::get().create_stream(cuda::stream::sync);
-		std::cout
+		::std::cout
 			<< "A new CUDA stream with no priority specified defaults to having priority "
 			<< stream.priority() << ".\n";
 		stream.enqueue.kernel_launch(print_message<N,1>, single_thread_config, message<N>("I can see my house!"));
@@ -124,32 +124,32 @@ int main(int argc, char **argv)
 	// Stream synchronization policy and attribute copying
 
 	auto initial_policy = stream_1.synchronization_policy();
-	std::cout
+	::std::cout
 		<< "Initial stream synchronization policy is "
 		<< get_policy_name(initial_policy) << " (numeric value: " << (int) initial_policy << ")\n";
 	if (initial_policy != stream_2.synchronization_policy()) {
-		throw std::logic_error("Different synchronization policies for streams created the same way");
+		throw ::std::logic_error("Different synchronization policies for streams created the same way");
 	}
 	cuda::stream::synchronization_policy_t alt_policy =
 		(initial_policy == cuda::stream::yield) ? cuda::stream::block : cuda::stream::yield;
 	stream_2.set_synchronization_policy(alt_policy);
 	auto new_s2_policy = stream_2.synchronization_policy();
 	if (alt_policy != new_s2_policy) {
-		std::stringstream ss;
+		::std::stringstream ss;
 		ss
 			<< "Got a different synchronization policy (" << get_policy_name(new_s2_policy) << ")"
 			<< " than the one we set the stream to (" << get_policy_name(alt_policy) << ")\n";
-		throw std::logic_error(ss.str());
+		throw ::std::logic_error(ss.str());
 	}
-	std::cout << "Overwriting all attributes of stream 1 with those of stream 2.\n";
+	::std::cout << "Overwriting all attributes of stream 1 with those of stream 2.\n";
 	cuda::copy_attributes(stream_1, stream_2);
 	auto s1_policy_after_copy = stream_1.synchronization_policy();
 	if (alt_policy != s1_policy_after_copy) {
-		std::stringstream ss;
+		::std::stringstream ss;
 		ss
 			<< "Got a different synchronization policy (" << get_policy_name(s1_policy_after_copy) << ")"
 			<< " than the one we expected after attribute-copying (" << get_policy_name(alt_policy) << ")\n";
-		throw std::logic_error(ss.str());
+		throw ::std::logic_error(ss.str());
 	}
 #endif
 
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
 			cuda::memory::managed::initial_visibility_t::to_supporters_of_concurrent_managed_access:
 			cuda::memory::managed::initial_visibility_t::to_all_devices);
 	print_first_char(buffer.get());
-	std::fill(buffer.get(), buffer.get() + buffer_size, 'a');
+	::std::fill(buffer.get(), buffer.get() + buffer_size, 'a');
 	print_first_char(buffer.get());
 
 	auto event_1 = cuda::event::create(device, cuda::event::sync_by_blocking);
@@ -168,7 +168,7 @@ int main(int argc, char **argv)
 	stream_1.enqueue.memset(buffer.get(), 'b', buffer_size);
 	stream_1.enqueue.host_function_call(
 		[&buffer](cuda::stream_t) {
-			std::cout << "Callback from stream 1!... \n";
+			::std::cout << "Callback from stream 1!... \n";
 			print_first_char(buffer.get());
 		}
 	);
@@ -189,9 +189,9 @@ int main(int argc, char **argv)
 	print_first_char(buffer.get());
 	// cuda::memory::managed::free(buffer);
 	bool idleness_2 = stream_2.has_work_remaining();
-	std::cout << std::boolalpha
+	::std::cout << ::std::boolalpha
 		<< "Did stream 2 have work before device-level synchronization? " << (idleness_1 ? "yes" : "no") << "\n"
 		<< "Did stream 2 have work after  device-level synchronization? " << (idleness_2 ? "yes" : "no") << "\n";
-	std::cout << "\nSUCCESS\n";
+	::std::cout << "\nSUCCESS\n";
 	return EXIT_SUCCESS;
 }

--- a/examples/by_runtime_api_module/unified_addressing.cpp
+++ b/examples/by_runtime_api_module/unified_addressing.cpp
@@ -50,7 +50,7 @@ void pointer_properties(const cuda::device_t& device)
 		auto ptr_mem_type = cuda::memory::type_of(raw_pointers[i]);
 		assert_(ptr_mem_type == cuda::memory::type_t::device_ or ptr_mem_type == cuda::memory::type_t::unified_);
 		if (i == 0) {
-			std::cout << "The memory type reported for pointers to memory allocated on the device is: " << memory_type_name(ptr_mem_type) << "\n";
+			::std::cout << "The memory type reported for pointers to memory allocated on the device is: " << memory_type_name(ptr_mem_type) << "\n";
 		}
 		assert_(pointers[i].get_for_device() == raw_pointers[i]);
 		try {
@@ -78,9 +78,9 @@ void pointer_properties(const cuda::device_t& device)
 		assert_(range == range_for_offset_ptr);
 		assert_(range_for_offset_ptr.start() == raw_pointers[i]);
 #endif
-//		std::cout << "range_for_offset_ptr.start() == " << range_for_offset_ptr.start() << '\n';
-//		std::cout << "range_for_offset_ptr.size() == " << range_for_offset_ptr.size() << '\n';
-//		std::cout << "offset_ptr == " << offset_ptr.get() << '\n';
+//		::std::cout << "range_for_offset_ptr.start() == " << range_for_offset_ptr.start() << '\n';
+//		::std::cout << "range_for_offset_ptr.size() == " << range_for_offset_ptr.size() << '\n';
+//		::std::cout << "offset_ptr == " << offset_ptr.get() << '\n';
 
 		// Consider testing:
 		//	CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE
@@ -101,16 +101,16 @@ void wrapped_pointers_and_regions(const cuda::device_t& device)
 
 	auto ptr = cuda::memory::pointer::wrap(memory_region.start());
 
-	std::cout
+	::std::cout
 		<< "Verifying a wrapper for raw pointer " << memory_region.start()
-		<< " allocated on the CUDA device." << std::endl;
+		<< " allocated on the CUDA device." << ::std::endl;
 
 	switch (cuda::memory::type_of(ptr)) {
 	using namespace cuda::memory;
 	case host_:         die_("Pointer incorrectly reported to point into host memory"); break;
 	case array:         die_("Pointer incorrectly reported to point to array memory"); break;
 //	case unregistered_memory: die_("Pointer incorrectly reported to point to \"unregistered\" memory"); break;
-	case unified_:       std::cout << "Allocated global-device-memory pointer reported to be of unified memory type.";
+	case unified_:       ::std::cout << "Allocated global-device-memory pointer reported to be of unified memory type.";
 		// die_("Pointer incorrectly reported not to point to managed memory"); break;
 	case device_:       break;
 	}
@@ -125,7 +125,7 @@ void wrapped_pointers_and_regions(const cuda::device_t& device)
 #endif // CUDA_VERSION >= 9020
 	(ptr.get() == memory_region.start()) or die_("Invalid get() output");
 	if (ptr.get_for_device() != memory_region.start()) {
-		std::stringstream ss;
+		::std::stringstream ss;
 		ss
 			<< "Reported device-side address isn't the address we get from allocation: "
 			<< ptr.get_for_device() << " != " << memory_region.start();
@@ -133,7 +133,7 @@ void wrapped_pointers_and_regions(const cuda::device_t& device)
 	}
 	try {
 		auto host_side_ptr = ptr.get_for_host();
-		std::stringstream ss;
+		::std::stringstream ss;
 		ss << "Unexpected success getting a host-side pointer for a device-only allocation; allocated pointer: "
 				<< ptr.get() << ", " << " host-side pointer: " << host_side_ptr;
 	}
@@ -147,10 +147,10 @@ void wrapped_pointers_and_regions(const cuda::device_t& device)
 int main(int argc, char **argv)
 {
 	cuda::device::id_t device_id =  (argc > 1) ?
-		std::stoi(argv[1]) : cuda::device::default_device_id;
+		::std::stoi(argv[1]) : cuda::device::default_device_id;
 	auto device = cuda::device::get(device_id);
 
-	std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")" << std::endl;
+	::std::cout << "Using CUDA device " << device.name() << " (having device ID " << device.id() << ")" << ::std::endl;
 
 	tests::wrapped_pointers_and_regions(device);
 
@@ -159,6 +159,6 @@ int main(int argc, char **argv)
 #endif // CUDA_VERSION >= 9020
 
 
-	std::cout << "\nSUCCESS\n";
+	::std::cout << "\nSUCCESS\n";
 	return EXIT_SUCCESS;
 }

--- a/examples/by_runtime_api_module/version_management.cpp
+++ b/examples/by_runtime_api_module/version_management.cpp
@@ -11,9 +11,9 @@
 #include <cuda/api/miscellany.hpp>
 #include <cuda/api/versions.hpp>
 
-[[noreturn]] void die_(const std::string& message)
+[[noreturn]] void die_(const ::std::string& message)
 {
-	std::cerr << message << "\n";
+	::std::cerr << message << "\n";
 	exit(EXIT_FAILURE);
 }
 
@@ -25,18 +25,18 @@ int main(int, char **)
 	}
 
 	auto runtime_version = cuda::version_numbers::runtime();
-	std::cout << "Using CUDA runtime version " << runtime_version << ".\n";
+	::std::cout << "Using CUDA runtime version " << runtime_version << ".\n";
 
 	auto driver_supported_version = cuda::version_numbers::driver();
 	if (driver_supported_version == cuda::version_numbers::none()) {
-		std::cout << "There is no CUDA driver installed, so no CUDA runtime version is supported\n";
+		::std::cout << "There is no CUDA driver installed, so no CUDA runtime version is supported\n";
 	}
 	else {
-		std::cout
+		::std::cout
 			<< "The nVIDIA GPU driver supports runtime version " << driver_supported_version
 			<< " at the highest, so the runtime used right now "
 			<< (runtime_version <= driver_supported_version ? "IS" : "IS NOT") << " supported by the driver.\n";
 	}
-	std::cout << "SUCCESS\n";
+	::std::cout << "SUCCESS\n";
 	return EXIT_SUCCESS;
 }

--- a/examples/common.hpp
+++ b/examples/common.hpp
@@ -21,8 +21,8 @@ struct compilation_options_t;
 } // namespace rtc
 } // namespace cuda
 
-void report_current_context(const std::string& prefix);
-void report_context_stack(const std::string& prefix);
+void report_current_context(const ::std::string& prefix);
+void report_context_stack(const ::std::string& prefix);
 inline void print_compilation_options(cuda::rtc::compilation_options_t compilation_options);
 
 #include <cuda/api.hpp>
@@ -78,42 +78,42 @@ const char* memory_type_name(cuda::memory::type_t mem_type)
 
 namespace std {
 
-std::ostream& operator<<(std::ostream& os, cuda::device::compute_capability_t cc)
+::std::ostream& operator<<(::std::ostream& os, cuda::device::compute_capability_t cc)
 {
     return os << cc.major() << '.' << cc.minor();
 }
 
-std::ostream& operator<<(std::ostream& os, cuda::multiprocessor_cache_preference_t pref)
+::std::ostream& operator<<(::std::ostream& os, cuda::multiprocessor_cache_preference_t pref)
 {
 	return (os << cache_preference_name(pref));
 }
 
-std::ostream& operator<<(std::ostream& os, cuda::context::host_thread_synch_scheduling_policy_t pref)
+::std::ostream& operator<<(::std::ostream& os, cuda::context::host_thread_synch_scheduling_policy_t pref)
 {
 	return (os << host_thread_synch_scheduling_policy_name(pref));
 }
 
-std::ostream& operator<<(std::ostream& os, cuda::context::handle_t handle)
+::std::ostream& operator<<(::std::ostream& os, cuda::context::handle_t handle)
 {
 	return (os << cuda::detail_::ptr_as_hex(handle));
 }
 
-std::ostream& operator<<(std::ostream& os, const cuda::context_t& context)
+::std::ostream& operator<<(::std::ostream& os, const cuda::context_t& context)
 {
 	return os << "[device " << context.device_id() << " handle " << context.handle() << ']';
 }
 
-std::ostream& operator<<(std::ostream& os, const cuda::device_t& device)
+::std::ostream& operator<<(::std::ostream& os, const cuda::device_t& device)
 {
 	return os << cuda::device::detail_::identify(device.id());
 }
 
-std::ostream& operator<<(std::ostream& os, const cuda::stream_t& stream)
+::std::ostream& operator<<(::std::ostream& os, const cuda::stream_t& stream)
 {
 	return os << cuda::stream::detail_::identify(stream.handle(), stream.device().id());
 }
 
-std::ostream &operator<<(std::ostream &os, const cuda::rtc::compilation_options_t &opts)
+::std::ostream &operator<<(::std::ostream &os, const cuda::rtc::compilation_options_t &opts)
 {
 	auto marshalled = opts.marshal();
 //	os << '(' << marshalled.option_ptrs().size() << ") compilation options: ";
@@ -126,9 +126,9 @@ std::ostream &operator<<(std::ostream &os, const cuda::rtc::compilation_options_
 	return os;
 }
 
-std::string to_string(const cuda::context_t& context)
+::std::string to_string(const cuda::context_t& context)
 {
-	std::stringstream ss;
+	::std::stringstream ss;
 	ss.clear();
 	ss << context;
 	return ss.str();
@@ -136,9 +136,9 @@ std::string to_string(const cuda::context_t& context)
 
 } // namespace std
 
-[[noreturn]] bool die_(const std::string& message)
+[[noreturn]] bool die_(const ::std::string& message)
 {
-	std::cerr << message << "\n";
+	::std::cerr << message << "\n";
 	exit(EXIT_FAILURE);
 }
 
@@ -146,75 +146,75 @@ std::string to_string(const cuda::context_t& context)
 { \
 	auto evaluation_result = (cond); \
 	if (not evaluation_result) \
-		die_("Assertion failed at line " + std::to_string(__LINE__) + ": " #cond); \
+		die_("Assertion failed at line " + ::std::to_string(__LINE__) + ": " #cond); \
 }
 
 
-void report_current_context(const std::string& prefix = "")
+void report_current_context(const ::std::string& prefix = "")
 {
-	if (not prefix.empty()) { std::cout << prefix << ", the current context is: "; }
-	else std::cout << "The current context is: ";
+	if (not prefix.empty()) { ::std::cout << prefix << ", the current context is: "; }
+	else ::std::cout << "The current context is: ";
 	if (not cuda::context::current::exists()) {
-		std::cout << "(None)" << std::endl;
+		::std::cout << "(None)" << ::std::endl;
 	}
 	else {
 		auto cc = cuda::context::current::get();
-		std::cout << cc << std::endl;
+		::std::cout << cc << ::std::endl;
 	}
 }
 
 void print_context_stack()
 {
 	if (not cuda::context::current::exists()) {
-		std::cout << "(Context stack is empty)" << std::endl;
+		::std::cout << "(Context stack is empty)" << ::std::endl;
 		return;
 	}
-	std::vector<cuda::context::handle_t> contexts;
+	::std::vector<cuda::context::handle_t> contexts;
 	while(cuda::context::current::exists()) {
 		contexts.push_back(cuda::context::current::detail_::pop());
 	}
-//	std::cout << "" << contexts.size() << " contexts; top to bottom:\n";
+//	::std::cout << "" << contexts.size() << " contexts; top to bottom:\n";
 	for (auto handle : contexts) {
 		auto device_id = cuda::context::detail_::get_device_id(handle);
-		std::cout << handle << " for device " << device_id;
+		::std::cout << handle << " for device " << device_id;
 		if (cuda::context::detail_::is_primary(handle)) {
-			std::cout << " (primary, "
+			::std::cout << " (primary, "
 				<< (cuda::device::primary_context::detail_::is_active(device_id) ? "active" : "inactive")
 				<< ')';
 		}
-		std::cout << '\n';
+		::std::cout << '\n';
 	}
 	for (auto it = contexts.rbegin(); it != contexts.rend(); it++) {
 		cuda::context::current::detail_::push(*it);
 	}
 }
 
-void report_primary_context_activity(const std::string& prefix = "")
+void report_primary_context_activity(const ::std::string& prefix = "")
 {
-	if (not prefix.empty()) { std::cout << prefix << ", "; }
-	std::cout << "Device primary contexts activity: ";
+	if (not prefix.empty()) { ::std::cout << prefix << ", "; }
+	::std::cout << "Device primary contexts activity: ";
 	for(auto device : cuda::devices()) {
-		std::cout << device.id() << ": "
+		::std::cout << device.id() << ": "
 				  << (cuda::device::primary_context::detail_::is_active(device.id()) ? "ACTIVE" : "inactive")
 				  << "  ";
 	}
-	std::cout << '\n';
+	::std::cout << '\n';
 }
 
-void report_context_stack(const std::string& prefix = "")
+void report_context_stack(const ::std::string& prefix = "")
 {
-	if (not prefix.empty()) { std::cout << prefix << ", the context stack is (top to bottom):\n"; }
-	std::cout << "-----------------------------------------------------\n";
+	if (not prefix.empty()) { ::std::cout << prefix << ", the context stack is (top to bottom):\n"; }
+	::std::cout << "-----------------------------------------------------\n";
 	print_context_stack();
-	std::cout << "---\n";
+	::std::cout << "---\n";
 	report_primary_context_activity();
-	std::cout << "-----------------------------------------------------\n" << std::flush;
+	::std::cout << "-----------------------------------------------------\n" << ::std::flush;
 }
 
 
 // Note: This will only work correctly for positive values
 template <typename U1, typename U2>
-typename std::common_type<U1,U2>::type div_rounding_up(U1 dividend, U2 divisor)
+typename ::std::common_type<U1,U2>::type div_rounding_up(U1 dividend, U2 divisor)
 {
 	return dividend / divisor + !!(dividend % divisor);
 }
@@ -222,9 +222,9 @@ typename std::common_type<U1,U2>::type div_rounding_up(U1 dividend, U2 divisor)
 inline void print_compilation_options(cuda::rtc::compilation_options_t compilation_options)
 {
 	auto marshalled = compilation_options.marshal();
-	std::cout << "Compiling with " << marshalled.option_ptrs().size() << " compilation options:\n";
+	::std::cout << "Compiling with " << marshalled.option_ptrs().size() << " compilation options:\n";
 	for (auto opt: marshalled.option_ptrs()) {
-		std::cout << "Option: " << opt << '\n';
+		::std::cout << "Option: " << opt << '\n';
 	}
 }
 

--- a/examples/modified_cuda_samples/helper_cuda.hpp
+++ b/examples/modified_cuda_samples/helper_cuda.hpp
@@ -29,11 +29,11 @@ void ensure_device_is_usable(const cuda::device_t device)
 	auto properties = device.properties();
 
 	if (not properties.usable_for_compute()) {
-		die_("Error: device " + std::to_string(device.id()) + "is running with <Compute Mode Prohibited>.");
+		die_("Error: device " + ::std::to_string(device.id()) + "is running with <Compute Mode Prohibited>.");
 	}
 
 	if (properties.compute_capability().major() < 1) {
-		die_("CUDA device " + std::to_string(device.id()) + " does not support CUDA.\n");
+		die_("CUDA device " + ::std::to_string(device.id()) + " does not support CUDA.\n");
 	}
 }
 
@@ -46,9 +46,9 @@ inline int get_device_with_highest_gflops()
 		die_("get_device_with_highest_gflops() CUDA error: no devices supporting CUDA.");
 	}
 
-	std::vector<cuda::device::id_t> device_ids(device_count);
-	std::iota(device_ids.begin(), device_ids.end(), 0);
-	(void) std::remove_if(device_ids.begin(), device_ids.end(),
+	::std::vector<cuda::device::id_t> device_ids(device_count);
+	::std::iota(device_ids.begin(), device_ids.end(), 0);
+	(void) ::std::remove_if(device_ids.begin(), device_ids.end(),
 		[](cuda::device::id_t id) {
 			auto properties = cuda::device::get(id).properties();
 			return !properties.usable_for_compute()
@@ -60,7 +60,7 @@ inline int get_device_with_highest_gflops()
 	}
 	if (device_ids.size() == 1) { return *device_ids.begin(); }
 
-	auto iterator = std::max_element(device_ids.begin(),device_ids.end(),
+	auto iterator = ::std::max_element(device_ids.begin(),device_ids.end(),
 		[](cuda::device::id_t id_1, cuda::device::id_t id_2) {
 			auto cc_1 = cuda::device::get(id_1).properties().compute_capability();
 			auto cc_2 = cuda::device::get(id_2).properties().compute_capability();
@@ -69,7 +69,7 @@ inline int get_device_with_highest_gflops()
 	);
 	auto best_sm_arch =	cuda::device::get(*iterator).properties().major;
 	if (best_sm_arch > 2) {
-		(void) std::remove_if(device_ids.begin(), device_ids.end(),
+		(void) ::std::remove_if(device_ids.begin(), device_ids.end(),
 			[best_sm_arch](cuda::device::id_t id) {
 				return cuda::device::get(id).properties().compute_capability().major() < (unsigned) best_sm_arch;
 			}
@@ -80,7 +80,7 @@ inline int get_device_with_highest_gflops()
 		auto properties = cuda::device::get(device_id).properties();
 		return properties.max_in_flight_threads_on_device() * properties.clockRate;
 	};
-	iterator = std::max_element(device_ids.begin(),device_ids.end(),
+	iterator = ::std::max_element(device_ids.begin(),device_ids.end(),
 		[&performance_estimator](cuda::device::id_t id_1, cuda::device::id_t id_2) {
 			return performance_estimator(id_1) < performance_estimator(id_2);
 		}
@@ -108,9 +108,9 @@ inline cuda::device_t chooseCudaDevice(int argc, const char **argv)
 	{
 		// Otherwise pick the device with highest Gflops/s
 		auto best_device = cuda::device::get(get_device_with_highest_gflops());
-		std::cout << "GPU Device " << best_device.id() << ": ";
-		std::cout << "\"" << best_device.name() << "\" ";
-		std::cout << "with compute capability " << best_device.properties().compute_capability() << "\n";
+		::std::cout << "GPU Device " << best_device.id() << ": ";
+		::std::cout << "\"" << best_device.name() << "\" ";
+		::std::cout << "with compute capability " << best_device.properties().compute_capability() << "\n";
 		return best_device;
 	}
 }

--- a/examples/modified_cuda_samples/helper_string.h
+++ b/examples/modified_cuda_samples/helper_string.h
@@ -450,18 +450,18 @@ inline char *sdkFindFilePath(const char *filename, const char *executable_path)
     };
 
     // Extract the executable name
-    std::string executable_name;
+    ::std::string executable_name;
 
     if (executable_path != 0)
     {
-        executable_name = std::string(executable_path);
+        executable_name = ::std::string(executable_path);
 
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
         // Windows path delimiter
         size_t delimiter_pos = executable_name.find_last_of('\\');
         executable_name.erase(0, delimiter_pos + 1);
 
-        if (executable_name.rfind(".exe") != std::string::npos)
+        if (executable_name.rfind(".exe") != ::std::string::npos)
         {
             // we strip .exe, only if the .exe is found
             executable_name.resize(executable_name.size() - 4);
@@ -477,12 +477,12 @@ inline char *sdkFindFilePath(const char *filename, const char *executable_path)
     // Loop over all search paths and return the first hit
     for (unsigned int i = 0; i < sizeof(searchPath)/sizeof(char *); ++i)
     {
-        std::string path(searchPath[i]);
+        ::std::string path(searchPath[i]);
         size_t executable_name_pos = path.find("<executable_name>");
 
         // If there is executable_name variable in the searchPath
         // replace it with the value
-        if (executable_name_pos != std::string::npos)
+        if (executable_name_pos != ::std::string::npos)
         {
             if (executable_path != 0)
             {

--- a/examples/modified_cuda_samples/memMapIPCDrv/child.cpp
+++ b/examples/modified_cuda_samples/memMapIPCDrv/child.cpp
@@ -24,7 +24,7 @@
 #include <sstream>
 #include <memory>
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 #include <filesystem>
 #endif
 

--- a/examples/modified_cuda_samples/p2pBandwidthLatencyTest/p2pBandwidthLatencyTest.cu
+++ b/examples/modified_cuda_samples/p2pBandwidthLatencyTest/p2pBandwidthLatencyTest.cu
@@ -38,11 +38,11 @@ struct command_line_options {
 
 template <typename T>
 struct square_matrix {
-	using size_type = typename std::vector<T>::size_type;
-	std::vector<T> elements;
+	using size_type = typename ::std::vector<T>::size_type;
+	::std::vector<T> elements;
 	size_type leg;
 
-	static square_matrix make(std::size_t leg)
+	static square_matrix make(::std::size_t leg)
 	{
 		square_matrix<T> result;
 		result.elements.resize(leg*leg);
@@ -104,7 +104,7 @@ __global__ void copyp2p(
 ///////////////////////////////////////////////////////////////////////////
 void printHelp(void)
 {
-    std::cout
+    ::std::cout
         << "Usage:  p2pBandwidthLatencyTest [OPTION]...\n"
         << "Tests bandwidth/latency of GPU pairs using P2P and without P2P\n"
         << "\n"
@@ -117,21 +117,21 @@ void printHelp(void)
 void checkP2Paccess()
 {
     for (auto device : cuda::devices()) {
-    	static_assert(std::is_same<decltype(device), cuda::device_t>::value, "Unexpected type");
+    	static_assert(::std::is_same<decltype(device), cuda::device_t>::value, "Unexpected type");
         for (auto peer : cuda::devices()) {
             if ((cuda::device_t)device != (cuda::device_t)peer) {
                 auto access = cuda::device::peer_to_peer::can_access(device, peer);
-                std::cout << "Device " << device.id() << (access ? " CAN" : " CANNOT") << " access Peer Device " << peer.id() << "\n";
+                ::std::cout << "Device " << device.id() << (access ? " CAN" : " CANNOT") << " access Peer Device " << peer.id() << "\n";
             }
         }
     }
-    std::cout << "\nNote: In case a device doesn't have P2P access to other one, it falls back to normal memcopy procedure.\nSo you can see lesser Bandwidth (GB/s) and unstable Latency (us) in those cases.\n\n";
+    ::std::cout << "\nNote: In case a device doesn't have P2P access to other one, it falls back to normal memcopy procedure.\nSo you can see lesser Bandwidth (GB/s) and unstable Latency (us) in those cases.\n\n";
 }
 
 void enqueue_p2p_copy(
     int *dest,
     int *src,
-    std::size_t num_elems,
+    ::std::size_t num_elems,
     int repeat,
     bool p2paccess,
     P2PEngine p2p_mechanism,
@@ -237,7 +237,7 @@ void outputBandwidthMatrix(P2PEngine mechanism, bool test_p2p, P2PDataTransfer p
             *flag = 1;
             streams[i].synchronize();
 
-            using usec_duration_t = std::chrono::duration<double, std::micro>;
+            using usec_duration_t = ::std::chrono::duration<double, ::std::micro>;
             usec_duration_t duration ( cuda::event::time_elapsed_between(start[i], stop[i]) );
 
             double gb = numElems * sizeof(int) * repeat / (double)1e9;
@@ -252,7 +252,7 @@ void outputBandwidthMatrix(P2PEngine mechanism, bool test_p2p, P2PDataTransfer p
         }
     }
 
-    std::cout << "Unidirectional P2P=" << (test_p2p ? "Enabled": "Disabled") << " Bandwidth " << (p2p_method == P2P_READ ? "(P2P Reads) " : "") << "Matrix (GB/s)\n";
+    ::std::cout << "Unidirectional P2P=" << (test_p2p ? "Enabled": "Disabled") << " Bandwidth " << (p2p_method == P2P_READ ? "(P2P Reads) " : "") << "Matrix (GB/s)\n";
 
 	print(bandwidthMatrix, "D\\D");
 
@@ -260,8 +260,8 @@ void outputBandwidthMatrix(P2PEngine mechanism, bool test_p2p, P2PDataTransfer p
 
 void print(const square_matrix<double> &bandwidthMatrix, const char* axis_cross_label)
 {
-	constexpr const std::size_t width = bandwidth::field_width;
-	cout << std::setw(width) << axis_cross_label;
+	constexpr const ::std::size_t width = bandwidth::field_width;
+	cout << ::std::setw(width) << axis_cross_label;
 
 	for (auto device : cuda::devices()) {
 		cout << setw(width) << device.id() << ' ';
@@ -362,7 +362,7 @@ void outputBidirectionalBandwidthMatrix(P2PEngine p2p_mechanism, bool test_p2p)
             streams_0[i].synchronize();
             streams_1[j].synchronize();
 
-            using seconds_duration_t = std::chrono::duration<double>;
+            using seconds_duration_t = ::std::chrono::duration<double>;
             seconds_duration_t duration ( cuda::event::time_elapsed_between(start[i], stop[i]) );
 
             double gb = 2.0 * numElems * sizeof(int) * repeat / (double)1e9;
@@ -377,7 +377,7 @@ void outputBidirectionalBandwidthMatrix(P2PEngine p2p_mechanism, bool test_p2p)
         }
     }
 
-    std::cout << "Bidirectional P2P=" << (test_p2p ? "Enabled": "Disabled") << " Bandwidth Matrix (GB/s)\n";
+    ::std::cout << "Bidirectional P2P=" << (test_p2p ? "Enabled": "Disabled") << " Bandwidth Matrix (GB/s)\n";
 
     print(bandwidthMatrix, "D\\D");
 }
@@ -433,7 +433,7 @@ void outputLatencyMatrix(P2PEngine p2p_mechanism, bool test_p2p, P2PDataTransfer
             streams[i].enqueue.kernel_launch(delay, single_thread, flag, default_timeout_clocks);
             streams[i].enqueue.event(start[i]);
 
-            auto time_before_copy = std::chrono::high_resolution_clock::now();
+            auto time_before_copy = ::std::chrono::high_resolution_clock::now();
             if (i == j) {
                 // Perform intra-GPU, D2D copies
                 enqueue_p2p_copy(buffers[i].get(), buffersD2D[i].get(), numElems, repeat, p2p_access_possible, p2p_mechanism, streams[i]);
@@ -448,15 +448,15 @@ void outputLatencyMatrix(P2PEngine p2p_mechanism, bool test_p2p, P2PDataTransfer
                     enqueue_p2p_copy(buffers[i].get(), buffers[j].get(), numElems, repeat, p2p_access_possible, p2p_mechanism, streams[i]);
                 }
             }
-            auto time_after_copy = std::chrono::high_resolution_clock::now();
-            std::chrono::duration<double, std::micro> cpu_duration_ms = time_after_copy - time_before_copy;
+            auto time_after_copy = ::std::chrono::high_resolution_clock::now();
+            ::std::chrono::duration<double, ::std::micro> cpu_duration_ms = time_after_copy - time_before_copy;
 
             streams[i].enqueue.event(stop[i]);
             // Now that the work has been queued up, release the stream
             *flag = 1;
             streams[i].synchronize();
 
-            using usec_duration_t = std::chrono::duration<double, std::micro>;
+            using usec_duration_t = ::std::chrono::duration<double, ::std::micro>;
             usec_duration_t gpu_duration ( cuda::event::time_elapsed_between(start[i], stop[i]) );
 
             gpuLatencyMatrix(i, j) = gpu_duration.count() / repeat;
@@ -468,7 +468,7 @@ void outputLatencyMatrix(P2PEngine p2p_mechanism, bool test_p2p, P2PDataTransfer
         }
     }
 
-    std::cout
+    ::std::cout
         << "P2P=" << (test_p2p ? "Enabled": "Disabled") << " Latency "
         << (test_p2p ? (p2p_method == P2P_READ ? "(P2P Reads) " : "(P2P Writes) ") : "")
         << "Matrix (us)\n";
@@ -481,24 +481,24 @@ void outputLatencyMatrix(P2PEngine p2p_mechanism, bool test_p2p, P2PDataTransfer
 void print_connectivity_matrix()
 {
     //Check peer-to-peer connectivity
-    std::cout << "P2P Connectivity Matrix\n";
-    std::cout << "   D\\D ";
+    ::std::cout << "P2P Connectivity Matrix\n";
+    ::std::cout << "   D\\D ";
     for (auto device : cuda::devices()) {
-        std::cout << std::setw(bandwidth::field_width) << device.id() << ' ';
+        ::std::cout << ::std::setw(bandwidth::field_width) << device.id() << ' ';
     }
-    std::cout << "\n";
+    ::std::cout << "\n";
     for (auto device : cuda::devices()) {
-        std::cout << std::setw(bandwidth::field_width) << device.id() << ' ';
+        ::std::cout << ::std::setw(bandwidth::field_width) << device.id() << ' ';
         for (auto peer : cuda::devices()) {
             if (device != peer) {
                 auto access = cuda::device::peer_to_peer::can_access(device, peer);
-                std::cout << std::setw(bandwidth::field_width) << ((access) ? 1 : 0);
+                ::std::cout << ::std::setw(bandwidth::field_width) << ((access) ? 1 : 0);
             } else {
-                std::cout << std::setw(bandwidth::field_width) << 1;
+                ::std::cout << ::std::setw(bandwidth::field_width) << 1;
             }
-            std::cout << ' ';
+            ::std::cout << ' ';
         }
-        std::cout << "\n";
+        ::std::cout << "\n";
     }
 }
 
@@ -507,7 +507,7 @@ void list_devices()
     //output devices
     for (auto device : cuda::devices()) {
         auto properties = device.properties();
-        std::cout << "Device: " << device.id() << ", " << properties.name << ", PCI location " << properties.pci_id() << '\n';
+        ::std::cout << "Device: " << device.id() << ", " << properties.name << ", PCI location " << properties.pci_id() << '\n';
     }
 }
 
@@ -525,7 +525,7 @@ command_line_options handle_command_line(int argc, char** argv)
     }
     if (checkCmdLineFlag(argc, (const char**) (argv), "sm_copy")) {
 #if CUDA_VERSION <= 10000
-        std::cerr << "This mechanism is unsupported by this program before CUDA 10.0" << std::endl;
+        ::std::cerr << "This mechanism is unsupported by this program before CUDA 10.0" << ::std::endl;
         exit(EXIT_FAILURE);
 #else
         p2p_mechanism = SM;
@@ -537,7 +537,7 @@ command_line_options handle_command_line(int argc, char** argv)
 int main(int argc, char **argv)
 {
     command_line_options opts = handle_command_line(argc, argv);
-    std::cout << "[P2P (Peer-to-Peer) GPU Bandwidth Latency Test]\n";
+    ::std::cout << "[P2P (Peer-to-Peer) GPU Bandwidth Latency Test]\n";
 
     list_devices();
     checkP2Paccess();
@@ -564,5 +564,5 @@ int main(int argc, char **argv)
     {
         outputLatencyMatrix(opts.mechanism, do_measure_p2p, P2P_READ);
     }
-    std::cout << "\nNOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.\n";
+    ::std::cout << "\nNOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.\n";
 }

--- a/examples/modified_cuda_samples/simpleDrvRuntimePTX/simpleDrvRuntimePTX.cpp
+++ b/examples/modified_cuda_samples/simpleDrvRuntimePTX/simpleDrvRuntimePTX.cpp
@@ -18,7 +18,7 @@
 
 #include "../../common.hpp"
 
-std::string create_ptx_file()
+::std::string create_ptx_file()
 {
 	const char* ptx_file_contents = R"(
 	.version 6.5
@@ -82,22 +82,22 @@ std::string create_ptx_file()
 	char temp_filename[] = "caw-simple-drv-runtime-ptx-XXXXXX";
 	int file_descriptor = mkstemp(temp_filename);
 	if (file_descriptor == -1) {
-		throw std::runtime_error(std::string("Failed creating a temporary file using mkstemp(): ") + std::strerror(errno) + '\n');
+		throw ::std::runtime_error(::std::string("Failed creating a temporary file using mkstemp(): ") + ::std::strerror(errno) + '\n');
 	}
 	FILE* ptx_file = fdopen(file_descriptor, "w");
 #else
 	char temp_filename[L_tmpnam];
-	std::tmpnam(temp_filename);
+	::std::tmpnam(temp_filename);
 	FILE* ptx_file = fopen(temp_filename, "w");
 #endif
 	if (ptx_file == nullptr) {
-        throw std::runtime_error(std::string("Failed converting temporay file descriptor into a C library FILE structure: ") + std::strerror(errno) + '\n');
+        throw ::std::runtime_error(::std::string("Failed converting temporay file descriptor into a C library FILE structure: ") + ::std::strerror(errno) + '\n');
     }
 	if (fputs(ptx_file_contents, ptx_file) == EOF) {
-        throw std::runtime_error("Failed writing PTX to temporary file " + std::string(temp_filename) + ": " + std::strerror(errno) + '\n');
+        throw ::std::runtime_error("Failed writing PTX to temporary file " + ::std::string(temp_filename) + ": " + ::std::strerror(errno) + '\n');
     }
 	if (fclose(ptx_file) == EOF) {
-        throw std::runtime_error("Failed closing temporary PTX file " + std::string(temp_filename) + ": " + std::strerror(errno) + '\n');
+        throw ::std::runtime_error("Failed closing temporary PTX file " + ::std::string(temp_filename) + ": " + ::std::strerror(errno) + '\n');
     }
 	return temp_filename;
 }
@@ -105,7 +105,7 @@ std::string create_ptx_file()
 // Host code
 int main(int argc, char** argv)
 {
-    std::cout << "simpleDrvRuntime - PTX version.\n";
+    ::std::cout << "simpleDrvRuntime - PTX version.\n";
     int N = 50000;
     size_t  size = N * sizeof(float);
 
@@ -118,7 +118,7 @@ int main(int argc, char** argv)
 
 	// Being very cavalier about our command-line arguments here...
 	cuda::device::id_t device_id =  (argc > 1) ?
-		std::stoi(argv[1]) : cuda::device::default_device_id;
+		::std::stoi(argv[1]) : cuda::device::default_device_id;
 
     auto device = cuda::device::get(device_id);
 
@@ -142,13 +142,13 @@ int main(int argc, char** argv)
 
     stream.synchronize();
 
-	auto h_A = std::unique_ptr<float>(new float[N]);
-	auto h_B = std::unique_ptr<float>(new float[N]);
-	auto h_C = std::unique_ptr<float>(new float[N]);
+	auto h_A = ::std::unique_ptr<float>(new float[N]);
+	auto h_B = ::std::unique_ptr<float>(new float[N]);
+	auto h_C = ::std::unique_ptr<float>(new float[N]);
 
 	auto generator = []() { return rand() / (float) RAND_MAX; };
-	std::generate_n(h_A.get(), N, generator);
-	std::generate_n(h_B.get(), N, generator);
+	::std::generate_n(h_A.get(), N, generator);
+	::std::generate_n(h_B.get(), N, generator);
 
     // Allocate vectors in device memory
 	auto d_A = cuda::memory::device::make_unique<float[]>(device, N);
@@ -171,11 +171,11 @@ int main(int argc, char** argv)
 	stream.synchronize();
 
 	for (int i = 0; i < N; ++i) {
-		if (std::fabs(h_A.get()[i] + h_B.get()[i] - h_C.get()[i]) > 1e-5)  {
-			std::cerr << "Result verification failed at element " << i << "\n";
+		if (::std::fabs(h_A.get()[i] + h_B.get()[i] - h_C.get()[i]) > 1e-5)  {
+			::std::cerr << "Result verification failed at element " << i << "\n";
 			exit(EXIT_FAILURE);
 		}
 	}
-    std::cout << "SUCCESS\n";
+    ::std::cout << "SUCCESS\n";
     return EXIT_SUCCESS;
 }

--- a/examples/modified_cuda_samples/simpleDrvRuntimePTX/simpleDrvRuntimePTX.cpp
+++ b/examples/modified_cuda_samples/simpleDrvRuntimePTX/simpleDrvRuntimePTX.cpp
@@ -78,12 +78,18 @@ std::string create_ptx_file()
 	}
 	)";
 
+#if _POSIX_C_SOURCE >= 200809L
 	char temp_filename[] = "caw-simple-drv-runtime-ptx-XXXXXX";
-    int file_descriptor = mkstemp(temp_filename);
+	int file_descriptor = mkstemp(temp_filename);
 	if (file_descriptor == -1) {
-        throw std::runtime_error(std::string("Failed creating a temporary file using mkstemp(): ") + std::strerror(errno) + '\n');
-    }
+		throw std::runtime_error(std::string("Failed creating a temporary file using mkstemp(): ") + std::strerror(errno) + '\n');
+	}
 	FILE* ptx_file = fdopen(file_descriptor, "w");
+#else
+	char temp_filename[L_tmpnam];
+	std::tmpnam(temp_filename);
+	FILE* ptx_file = fopen(temp_filename, "w");
+#endif
 	if (ptx_file == nullptr) {
         throw std::runtime_error(std::string("Failed converting temporay file descriptor into a C library FILE structure: ") + std::strerror(errno) + '\n');
     }
@@ -99,7 +105,7 @@ std::string create_ptx_file()
 // Host code
 int main(int argc, char** argv)
 {
-    std::cout << "simpleDrvRuntime - PTX version..\n";
+    std::cout << "simpleDrvRuntime - PTX version.\n";
     int N = 50000;
     size_t  size = N * sizeof(float);
 

--- a/examples/modified_cuda_samples/simpleStreams/simpleStreams.cu
+++ b/examples/modified_cuda_samples/simpleStreams/simpleStreams.cu
@@ -72,7 +72,7 @@ bool check_resulting_data(const int *a, const int n, const int c)
 {
 	for (int i = 0; i < n; i++) {
 		if (a[i] != c) {
-			std::cerr << i << ": " << a[i] << " " << c << "\n";
+			::std::cerr << i << ": " << a[i] << " " << c << "\n";
 			return false;
 		}
 	}
@@ -81,7 +81,7 @@ bool check_resulting_data(const int *a, const int n, const int c)
 
 void printHelp()
 {
-	std::cout
+	::std::cout
 		<< "Usage: " << sSDKsample << " [options below]\n"
 		<< "\t--sync_method (" << (int) synch_policy_type::default_ << ") for CPU thread synchronization with GPU work."
 		<< "\t             Possible values: " << (int) synch_policy_type::heuristic << ", "
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
 	int nstreams = 4;               // number of streams for CUDA calls
 	int nreps = 5;                 // number of times each experiment is repeated; originally 10
 	int n = 2 * 1024 * 1024;       // number of ints in the data set; originally 2^16
-	std::size_t nbytes = n * sizeof(int);   // number of data bytes
+	::std::size_t nbytes = n * sizeof(int);   // number of data bytes
 	dim3 threads, blocks;           // kernel launch configuration
 	float scale_factor = 1.0f;
 
@@ -120,26 +120,26 @@ int main(int argc, char **argv)
 		|| synch_policy_arg == synch_policy_type::block)
 	{
 		synch_policy = (synch_policy_type) synch_policy_arg;
-			std::cout << "Device synchronization method set to: " <<
+			::std::cout << "Device synchronization method set to: " <<
 				  (synch_policy_type) synch_policy << "\n";
-		std::cout << "Setting reps to 100 to demonstrate steady state\n";
+		::std::cout << "Setting reps to 100 to demonstrate steady state\n";
 		nreps = 100;
 	}
 	else
 	{
-		std::cout << "Invalid command line option sync_method \"" << synch_policy << "\"\n";
+		::std::cout << "Invalid command line option sync_method \"" << synch_policy << "\"\n";
 		return EXIT_FAILURE;
 	}
 
 	if (checkCmdLineFlag(argc, (const char **)argv, "use_cuda_malloc_host"))
 	{
-		std::cout
+		::std::cout
 			<< "To simplify this example, support for using cuda_malloc_host instead of "
 			<< "pinned memory has been dropped.\n";
 		return EXIT_FAILURE;
 	}
 
-	std::cout << "\n> ";
+	::std::cout << "\n> ";
 	auto device = chooseCudaDevice(argc, (const char **)argv);
 	device.make_current();
 		// This is "necessary", for now, for the memory operations whose API is context-unaware,
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
 	auto compute_capability = properties.compute_capability();
 
 	if (compute_capability < cuda::device::compute_capability_t({1, 1}) ) {
-		std::cout << properties.name << " does not have Compute Capability 1.1 or newer. Reducing workload.\n";
+		::std::cout << properties.name << " does not have Compute Capability 1.1 or newer. Reducing workload.\n";
 	}
 
 	if (compute_capability.major() >= 2) {
@@ -164,32 +164,32 @@ int main(int argc, char **argv)
 	}
 
 	// Check if GPU can map host memory (Generic Method), if not then we override bPinGenericMemory to be false
-	std::cout << "Device: <" << properties.name << "> canMapHostMemory: "
+	::std::cout << "Device: <" << properties.name << "> canMapHostMemory: "
 			<< (properties.canMapHostMemory ? "Yes" : "No") << "\n";
 
 	if (not properties.can_map_host_memory())
 	{
-		std::cout << "Cannot allocate pinned memory (and map GPU device memory to it); aborting.\n";
+		::std::cout << "Cannot allocate pinned memory (and map GPU device memory to it); aborting.\n";
 		return EXIT_FAILURE;
 	}
 
 	// Anything that is less than 32 Cores will have scaled down workload
 	auto faux_cores_per_sm = compute_capability.max_in_flight_threads_per_processor();
 	auto faux_cores_overall = properties.max_in_flight_threads_on_device();
-	scale_factor = std::max((32.0f / faux_cores_overall), 1.0f);
+	scale_factor = ::std::max((32.0f / faux_cores_overall), 1.0f);
 	n = (int)rint((float)n / scale_factor);
 
-	std::cout << "> CUDA Capable: SM " << compute_capability.major() << "." << compute_capability.minor() << " hardware\n";
-	std::cout
+	::std::cout << "> CUDA Capable: SM " << compute_capability.major() << "." << compute_capability.minor() << " hardware\n";
+	::std::cout
 		<< "> " << properties.multiProcessorCount << " Multiprocessor(s)"
 		<< " x " << faux_cores_per_sm << " (Cores/Multiprocessor) = "
 		<< faux_cores_overall << " (Cores)\n";
 
-	std::cout << "> scale_factor = " << 1.0f/scale_factor << "\n";
-	std::cout << "> array_size   = " << n << "\n\n";
+	::std::cout << "> scale_factor = " << 1.0f/scale_factor << "\n";
+	::std::cout << "> array_size   = " << n << "\n\n";
 
 	// enable use of blocking sync, to reduce CPU usage
-	std::cout << "> Using CPU/GPU Device Synchronization method " << synch_policy << std::endl;
+	::std::cout << "> Using CPU/GPU Device Synchronization method " << synch_policy << ::std::endl;
 
 	synch_policy_type  policy;
 	switch(synch_policy) {
@@ -217,12 +217,12 @@ int main(int argc, char **argv)
 	auto d_c = cuda::memory::device::make_unique<int>(device);
 	cuda::memory::copy_single(d_c.get(), &c);
 
-	std::cout << "\nStarting Test\n";
+	::std::cout << "\nStarting Test\n";
 
 	// allocate and initialize an array of stream handles
-	std::vector<cuda::stream_t> streams;
-	std::generate_n(
-		std::back_inserter(streams), nstreams,
+	::std::vector<cuda::stream_t> streams;
+	::std::generate_n(
+		::std::back_inserter(streams), nstreams,
 		[&device]() {
 			// Note: we could omit the specific requirement of synchronization
 			// with the default stream, since that's the CUDA default - but I
@@ -245,7 +245,7 @@ int main(int argc, char **argv)
 	stop_event.record();
 	stop_event.synchronize(); // block until the event is actually recorded
 	auto time_memcpy = cuda::event::time_elapsed_between(start_event, stop_event);
-	std::cout << "memcopy:\t" << time_memcpy.count() << "\n";
+	::std::cout << "memcopy:\t" << time_memcpy.count() << "\n";
 
 	// time kernel
 	threads=dim3(512, 1);
@@ -257,7 +257,7 @@ int main(int argc, char **argv)
 	stop_event.record();
 	stop_event.synchronize();
 	auto time_kernel = cuda::event::time_elapsed_between(start_event, stop_event);
-	std::cout << "kernel:\t\t" << time_kernel.count() << "\n";
+	::std::cout << "kernel:\t\t" << time_kernel.count() << "\n";
 
 	//////////////////////////////////////////////////////////////////////
 	// time non-streamed execution for reference
@@ -275,7 +275,7 @@ int main(int argc, char **argv)
 	stop_event.record();
 	stop_event.synchronize();
 	auto elapsed_time = cuda::event::time_elapsed_between(start_event, stop_event);
-	std::cout << "non-streamed:\t" << elapsed_time.count() / nreps << "\n";
+	::std::cout << "non-streamed:\t" << elapsed_time.count() / nreps << "\n";
 
 	//////////////////////////////////////////////////////////////////////
 	// time execution with nstreams streams
@@ -313,12 +313,12 @@ int main(int argc, char **argv)
 	stop_event.record();
 	stop_event.synchronize();
 	elapsed_time = cuda::event::time_elapsed_between(start_event, stop_event);
-	std::cout << nstreams <<" streams:\t" << elapsed_time.count() / (float) nreps << "\n";
+	::std::cout << nstreams <<" streams:\t" << elapsed_time.count() / (float) nreps << "\n";
 
 	// check whether the output is correct
-	std::cout << "-------------------------------\n";
+	::std::cout << "-------------------------------\n";
 	if (not check_resulting_data(h_a.get(), n, c * nreps * niterations)) {
 		die_("Result check FAILED.");
 	}
-	std::cout << "\nSUCCESS\n";
+	::std::cout << "\nSUCCESS\n";
 }

--- a/examples/modified_cuda_samples/vectorAdd_nvrtc/vectorAdd_nvrtc.cpp
+++ b/examples/modified_cuda_samples/vectorAdd_nvrtc/vectorAdd_nvrtc.cpp
@@ -40,7 +40,7 @@ int main(void)
 	size_t size = numElements * sizeof(float);
 	auto kernel_name = "vectorAdd";
 
-	std::cout << "[Vector addition of " << numElements << " elements]\n";
+	::std::cout << "[Vector addition of " << numElements << " elements]\n";
 
 	auto device = cuda::device::current::get();
 	auto program = cuda::rtc::program::create(kernel_name, vectorAdd_source);
@@ -52,14 +52,14 @@ int main(void)
 	auto module = cuda::module::create(context, program);
 	auto vectorAdd = module.get_kernel(mangled_kernel_name);
 
-	// If we could rely on C++14, we would  use std::make_unique
-	auto h_A = std::unique_ptr<float[]>(new float[numElements]);
-	auto h_B = std::unique_ptr<float[]>(new float[numElements]);
-	auto h_C = std::unique_ptr<float[]>(new float[numElements]);
+	// If we could rely on C++14, we would  use ::std::make_unique
+	auto h_A = ::std::unique_ptr<float[]>(new float[numElements]);
+	auto h_B = ::std::unique_ptr<float[]>(new float[numElements]);
+	auto h_C = ::std::unique_ptr<float[]>(new float[numElements]);
 
 	auto generator = []() { return rand() / (float) RAND_MAX; };
-	std::generate(h_A.get(), h_A.get() + numElements, generator);
-	std::generate(h_B.get(), h_B.get() + numElements, generator);
+	::std::generate(h_A.get(), h_A.get() + numElements, generator);
+	::std::generate(h_B.get(), h_B.get() + numElements, generator);
 
 	auto d_A = cuda::memory::device::make_unique<float[]>(device, numElements);
 	auto d_B = cuda::memory::device::make_unique<float[]>(device, numElements);
@@ -73,7 +73,7 @@ int main(void)
 		.block_size(256)
 		.build();
 
-	std::cout
+	::std::cout
 	<< "CUDA kernel launch with " << launch_config.dimensions.grid.x
 	<< " blocks of " << launch_config.dimensions.block.x << " threads each\n";
 
@@ -86,14 +86,14 @@ int main(void)
 
 	// Verify that the result vector is correct
 	for (int i = 0; i < numElements; ++i) {
-		if (std::fabs(h_A.get()[i] + h_B.get()[i] - h_C.get()[i]) > 1e-5)  {
-			std::cerr << "Result verification failed at element " << i << "\n";
+		if (::std::fabs(h_A.get()[i] + h_B.get()[i] - h_C.get()[i]) > 1e-5)  {
+			::std::cerr << "Result verification failed at element " << i << "\n";
 			exit(EXIT_FAILURE);
 		}
 	}
 
-    std::cout << "Test PASSED\n";
-    std::cout << "SUCCESS\n";
+    ::std::cout << "Test PASSED\n";
+    ::std::cout << "SUCCESS\n";
 }
 
 

--- a/examples/other/array_management.cu
+++ b/examples/other/array_management.cu
@@ -43,18 +43,18 @@ __global__ void from_2D_texture_to_memory_space(cudaTextureObject_t texture_sour
 } // namespace kernels
 
 template <typename T>
-void check_output_is_iota(std::string name, const T* actual, size_t length) noexcept
+void check_output_is_iota(::std::string name, const T* actual, size_t length) noexcept
 {
 	bool failed { false };
 	for (size_t i = 0; i < length; ++i) {
 		if (actual[i] != i) {
 			if (not failed) {
-				std::cerr << name << ": Output does not matched expected values:\n";
+				::std::cerr << name << ": Output does not matched expected values:\n";
 			}
-			std::cerr << "output[" << std::setw(3) << i << "] = " << actual[i] << " != " << i << '\n';
+			::std::cerr << "output[" << ::std::setw(3) << i << "] = " << actual[i] << " != " << i << '\n';
 		}
 	}
-	if (failed) { std::cerr << '\n'; }
+	if (failed) { ::std::cerr << '\n'; }
 }
 
 void array_3d_example(cuda::device_t& device, size_t w, size_t h, size_t d) {
@@ -64,16 +64,16 @@ void array_3d_example(cuda::device_t& device, size_t w, size_t h, size_t d) {
 	auto arr = cuda::array::create<float>(device, dims);
 	assert_(arr.device() == device);
 	auto ptr_in = cuda::memory::managed::make_unique<float[]>(arr.size());
-	std::iota(ptr_in.get(), ptr_in.get() + arr.size(), 0);
+	::std::iota(ptr_in.get(), ptr_in.get() + arr.size(), 0);
 	auto ptr_out = cuda::memory::managed::make_unique<float[]>(arr.size());
 	cuda::memory::copy(arr, ptr_in.get());
 	cuda::texture_view tv(arr);
     assert_(tv.device() == device);
 	constexpr cuda::grid::block_dimension_t block_dim = 10;
 	constexpr auto block_dims = cuda::grid::block_dimensions_t::cube(block_dim);
-	assert(div_rounding_up(w, block_dim) <= std::numeric_limits<grid::dimension_t>::max());
-	assert(div_rounding_up(h, block_dim) <= std::numeric_limits<grid::dimension_t>::max());
-	assert(div_rounding_up(d, block_dim) <= std::numeric_limits<grid::dimension_t>::max());
+	assert(div_rounding_up(w, block_dim) <= ::std::numeric_limits<grid::dimension_t>::max());
+	assert(div_rounding_up(h, block_dim) <= ::std::numeric_limits<grid::dimension_t>::max());
+	assert(div_rounding_up(d, block_dim) <= ::std::numeric_limits<grid::dimension_t>::max());
 	const grid::dimensions_t grid_dims = {
 		grid::dimension_t( div_rounding_up(w, block_dim) ),
 		grid::dimension_t( div_rounding_up(h, block_dim) ),
@@ -104,12 +104,12 @@ void array_3d_example(cuda::device_t& device, size_t w, size_t h, size_t d) {
 template <typename T>
 void print_2d_array(const char* title, const T* a, size_t width, size_t height)
 {
-    std::cout << title << ":\n";
+    ::std::cout << title << ":\n";
 	for (size_t i = 0; i < height; ++i) {
 		for (size_t j = 0; j < width; ++j) {
-			std::cout << a[j + i * width] << ' ';
+			::std::cout << a[j + i * width] << ' ';
 		}
-		std::cout << '\n';
+		::std::cout << '\n';
 	}
 }
 
@@ -120,9 +120,9 @@ void array_2d_example(cuda::device_t& device, size_t w, size_t h)
 	const cuda::array::dimensions_t<2> dims = {w, h};
 	auto arr = cuda::array::create<float>(device , dims);
 	auto ptr_in = cuda::memory::managed::make_unique<float[]>(arr.size());
-	std::iota(ptr_in.get(), ptr_in.get() + arr.size(), 0);
+	::std::iota(ptr_in.get(), ptr_in.get() + arr.size(), 0);
 
-	std::cout << std::endl;
+	::std::cout << ::std::endl;
 
     print_2d_array("Data at ptr_in after initialization", ptr_in.get(), w, h);
 
@@ -131,8 +131,8 @@ void array_2d_example(cuda::device_t& device, size_t w, size_t h)
 
 	constexpr cuda::grid::block_dimension_t block_dim = 10;
 	constexpr auto block_dims = cuda::grid::block_dimensions_t::square(block_dim);
-	assert(div_rounding_up(w, block_dim) <= std::numeric_limits<grid::dimension_t>::max());
-	assert(div_rounding_up(h, block_dim) <= std::numeric_limits<grid::dimension_t>::max());
+	assert(div_rounding_up(w, block_dim) <= ::std::numeric_limits<grid::dimension_t>::max());
+	assert(div_rounding_up(h, block_dim) <= ::std::numeric_limits<grid::dimension_t>::max());
 	const cuda::grid::dimensions_t grid_dims = {
 		grid::dimension_t( div_rounding_up(w, block_dim) ),
 		grid::dimension_t( div_rounding_up(h, block_dim) ),
@@ -142,7 +142,7 @@ void array_2d_example(cuda::device_t& device, size_t w, size_t h)
     auto ptr_out = cuda::memory::managed::make_unique<float[]>(arr.size());
     // The following is to make it easier to notice if nothing get copied
     // to the output
-    std::iota(ptr_out.get(), ptr_out.get() + arr.size(), 90);
+    ::std::iota(ptr_out.get(), ptr_out.get() + arr.size(), 90);
 //    print_2d_array("Data at ptr_out after initialization", ptr_out.get(), w, h);
 
 	cuda::launch(
@@ -184,5 +184,5 @@ int main()
 	array_2d_example(device, w, h);
 	device.synchronize();
 
-	std::cout << "\nSUCCESS\n";
+	::std::cout << "\nSUCCESS\n";
 }

--- a/examples/other/io_compute_overlap_with_streams.cu
+++ b/examples/other/io_compute_overlap_with_streams.cu
@@ -54,8 +54,8 @@ cuda::launch_configuration_t make_linear_launch_config(
 {
     auto threads_per_block = device.properties().max_threads_per_block();
     auto num_blocks =  div_rounding_up(length, threads_per_block);
-    if (num_blocks > std::numeric_limits<cuda::grid::dimension_t>::max()) {
-        throw std::invalid_argument("Specified length exceeds CUDA's support for a linear grid");
+    if (num_blocks > ::std::numeric_limits<cuda::grid::dimension_t>::max()) {
+        throw ::std::invalid_argument("Specified length exceeds CUDA's support for a linear grid");
     }
     return cuda::make_launch_config((cuda::grid::dimensions_t) num_blocks, threads_per_block, cuda::no_dynamic_shared_memory);
 }
@@ -69,17 +69,17 @@ struct buffer_set_t {
     cuda::memory::device::unique_ptr<element_t[]> device_result;
 };
 
-std::vector<buffer_set_t> generate_buffers(
+::std::vector<buffer_set_t> generate_buffers(
     const cuda::device_t&  device,
     size_t                num_kernels,
     size_t                num_elements)
 {
     // device.make_current();
-    // TODO: This should be an std::array, but generating
+    // TODO: This should be an ::std::array, but generating
     // it is a bit tricky and I don't want to burden the example
     // with template wizardry
-    std::vector<buffer_set_t> buffers;
-    std::generate_n(std::back_inserter(buffers), num_kernels,
+    ::std::vector<buffer_set_t> buffers;
+    ::std::generate_n(::std::back_inserter(buffers), num_kernels,
         [&]() {
             return buffer_set_t {
                 // Sticking to C++11 here...
@@ -104,22 +104,22 @@ int main(int, char **)
     constexpr size_t num_elements    = 1e7;
 
     auto device = cuda::device::current::get();
-    std::cout << "Using CUDA device " << device.name() << " (having ID " << device.id() << ")\n";
+    ::std::cout << "Using CUDA device " << device.name() << " (having ID " << device.id() << ")\n";
 
-    std::cout << "Generating host buffers... " << std::flush;
+    ::std::cout << "Generating host buffers... " << ::std::flush;
     auto buffers = generate_buffers(device, num_kernels, num_elements);
-    std::cout << "done.\n" << std::flush;
+    ::std::cout << "done.\n" << ::std::flush;
 
-    std::vector<cuda::stream_t> streams;
+    ::std::vector<cuda::stream_t> streams;
     streams.reserve(num_kernels);
-    std::generate_n(std::back_inserter(streams), num_kernels,
+    ::std::generate_n(::std::back_inserter(streams), num_kernels,
         [&]() { return device.create_stream(cuda::stream::async); });
 
     auto common_launch_config = make_linear_launch_config(device, num_elements);
     auto buffer_size = num_elements * sizeof(element_t);
 
-    std::cout
-        << "Running " << num_kernels << " sequences of HtoD-kernel-DtoH, in parallel" << std::endl;
+    ::std::cout
+        << "Running " << num_kernels << " sequences of HtoD-kernel-DtoH, in parallel" << ::std::endl;
         // Unfortunately, we need to use indices here - unless we
         // had access to a zip iterator (e.g. boost::zip_iterator)
     for(size_t k = 0; k < num_kernels; k++) {
@@ -137,16 +137,16 @@ int main(int, char **)
         stream.enqueue.copy(buffer_set.host_result.get(), buffer_set.device_result.get(), buffer_size);
         stream.enqueue.host_function_call(
             [=](cuda::stream_t) {
-                std::cout
-                    << "Stream " << k+1 << " of " << num_kernels << " has concluded all work. " << std::endl;
+                ::std::cout
+                    << "Stream " << k+1 << " of " << num_kernels << " has concluded all work. " << ::std::endl;
             }
         );
     }
-    std::this_thread::sleep_for(std::chrono::microseconds(50000));
+    ::std::this_thread::sleep_for(::std::chrono::microseconds(50000));
     for(auto& stream : streams) { stream.synchronize(); }
     cuda::outstanding_error::ensure_none();
 
     // TODO: Consider checking for correctness here
 
-    std::cout << "\nSUCCESS" << std::endl;
+    ::std::cout << "\nSUCCESS" << ::std::endl;
 }

--- a/examples/other/jitify/jitify.cpp
+++ b/examples/other/jitify/jitify.cpp
@@ -49,7 +49,7 @@
 #include <string>
 #include <sstream>
 
-#if __cplusplus >= 201703
+#if (__cplusplus >= 201703) || (_MSVC_LANG >= 201703L)
 #include <filesystem>
 namespace fs = std::filesystem;
 #else
@@ -59,7 +59,7 @@ namespace fs = std::experimental::filesystem;
 
 template <typename T>
 bool are_close(T in, T out) {
-  return fabs(in - out) <= 1e-5f * fabs(in);
+	return fabs(in - out) <= 1e-5f * fabs(in);
 }
 
 /**
@@ -76,8 +76,8 @@ std::string append_kernel_instantiation(string_view program_source, string_view 
 	std::stringstream sstr;
 
 	sstr << program_source
-	     << "\n"
-	     << "template __global__ decltype(" << instantiation_name << ") " << instantiation_name << ";\n";
+		<< "\n"
+		<< "template __global__ decltype(" << instantiation_name << ") " << instantiation_name << ";\n";
 	return sstr.str();
 }
 
@@ -132,8 +132,8 @@ bool try_compilation(
 template <typename T>
 bool test_simple() {
 	const auto kernel_name = "my_kernel";
-  	const char* program_source =
-R"(template<int N, typename T>
+	const char* program_source =
+		R"(template<int N, typename T>
 __global__
 void my_kernel(T* data) {
     T data0 = data[0];
@@ -166,7 +166,7 @@ void my_kernel(T* data) {
 template <typename T>
 bool test_kernels() {
 	const char* my_header4_cuh_contents =
-R"(#pragma once
+		R"(#pragma once
 template<typename T>
 T pointless_func(T x) {
 	return x;
@@ -174,8 +174,8 @@ T pointless_func(T x) {
 #warning "Here!"
 )";
 
-  	const char* program_source =
-R"(
+	const char* program_source =
+		R"(
 #include "example_headers/my_header1.cuh"
 #include "example_headers/my_header2.cuh"
 #include "example_headers/my_header3.cuh"
@@ -195,14 +195,14 @@ void my_kernel2(float const* indata, float* outdata) {
     }
 };
 )";
-  	const char* kernel_names[2] = { "my_kernel1", "my_kernel2" };
+	const char* kernel_names[2] = { "my_kernel1", "my_kernel2" };
 
 	enum { C = 123 };
 	auto my_kernel2_instantiation_name = make_instantiation_name(kernel_names[1], std::to_string(C), type_name<T>());
-		// Note: In the original jitify.cpp function, there were 6 different equivalent ways to trigger an
-		// instantiation of the template. I don't see why that's at all useful, but regardless - here we
-		// instantiate by simply printing whatever is passed to the instantiation function (which is not
-		// part of the CUDA API wrappers, but is actually both straightforward and flexible).
+	// Note: In the original jitify.cpp function, there were 6 different equivalent ways to trigger an
+	// instantiation of the template. I don't see why that's at all useful, but regardless - here we
+	// instantiate by simply printing whatever is passed to the instantiation function (which is not
+	// part of the CUDA API wrappers, but is actually both straightforward and flexible).
 	std::string source_with_instantiation = append_kernel_instantiation(program_source, my_kernel2_instantiation_name);
 	std::vector<std::pair<const char*, const char*>> headers = {
 		{"example_headers/my_header4.cuh", my_header4_cuh_contents}
@@ -214,12 +214,12 @@ void my_kernel2(float const* indata, float* outdata) {
 	cuda::rtc::compilation_options_t options;
 	options.use_fast_math = true;
 	options.default_execution_space_is_device = true;
-		// This is necessary because the headers included by this program have functions without a
-		// device/host qualification - and those default to being host functions, which NVRTC doesn't
-		// compile.
+	// This is necessary because the headers included by this program have functions without a
+	// device/host qualification - and those default to being host functions, which NVRTC doesn't
+	// compile.
 	if (not try_compilation(program, device, options)) { return false; }
-		// Note: Headers whose sources were not provided to the program on creation will be sought after
-		// in the specified include directories (in our case, none), and the program's working directory.
+	// Note: Headers whose sources were not provided to the program on creation will be sought after
+	// in the specified include directories (in our case, none), and the program's working directory.
 	const char* mangled_kernel_names[2] = {
 		program.get_mangling_of(kernel_names[0]),
 		program.get_mangling_of(my_kernel2_instantiation_name)
@@ -248,7 +248,7 @@ bool test_constant()
 	constexpr int n_const = 3;
 
 	const char *const_program_source =
-R"(#pragma once
+		R"(#pragma once
 
 __constant__ int a;
 namespace b { __constant__ int a; }
@@ -358,6 +358,6 @@ int main(int, char**)
 		and test_constant_result
 		and test_constant_2_result
 #endif // CUDA_VERSION >= 10000
-	);
+		);
 }
 

--- a/examples/other/jitify/jitify.cpp
+++ b/examples/other/jitify/jitify.cpp
@@ -48,9 +48,14 @@
 #include <vector>
 #include <string>
 #include <sstream>
+
+#if __cplusplus >= 201703
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
 #include <experimental/filesystem>
-
-
+namespace fs = std::experimental::filesystem;
+#endif
 
 template <typename T>
 bool are_close(T in, T out) {
@@ -318,7 +323,6 @@ bool test_constant_2()
 
 int main(int, char**)
 {
-	namespace fs = std::experimental::filesystem;
 	fs::path extra_headers_dir { "example_headers" };
 	fs::exists(extra_headers_dir) or die_(
 		"Cannot run the jitify test without the extra headers directory " + extra_headers_dir.string());

--- a/examples/other/jitify/type_name.hpp
+++ b/examples/other/jitify/type_name.hpp
@@ -1,7 +1,7 @@
 #ifndef CUDA_API_WRAPPERS_TYPE_NAME_HPP
 #define CUDA_API_WRAPPERS_TYPE_NAME_HPP
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 #include <string_view>
 using std::string_view;
 #define CONSTEXPR_SINCE_2014 constexpr

--- a/examples/other/manipulate_current_device.cu
+++ b/examples/other/manipulate_current_device.cu
@@ -9,8 +9,8 @@
 
 void report_current_device()
 {
-	std::cout << "Runtime believes the current device index is: "
-		<< cuda::device::current::detail_::get_id() << std::endl;
+	::std::cout << "Runtime believes the current device index is: "
+		<< cuda::device::current::detail_::get_id() << ::std::endl;
 }
 
 int main()
@@ -29,31 +29,31 @@ int main()
 	assert_(cur_dev::get_id() == 0);
 	dev_idx[1] = (dev_idx[0] == 0) ? 1 : 0;
 	pc_handle[0] = pc::obtain_and_increase_refcount(dev_idx[0]);
-	std::cout << "Obtained primary context handle for device " << dev_idx[0]<< '\n';
+	::std::cout << "Obtained primary context handle for device " << dev_idx[0]<< '\n';
 	pc_handle[1] = pc::obtain_and_increase_refcount(dev_idx[1]);
-	std::cout << "Obtained primary context handle for device " << dev_idx[1]<< '\n';
+	::std::cout << "Obtained primary context handle for device " << dev_idx[1]<< '\n';
 	report_current_device();
 	cur_ctx::push(pc_handle[1]);
-	std::cout << "Pushed primary context handle for device " << dev_idx[1] << " onto the stack\n";
+	::std::cout << "Pushed primary context handle for device " << dev_idx[1] << " onto the stack\n";
 	report_current_device();
 	assert_(cur_dev::get_id() == dev_idx[1]);
 	auto ctx = context::create_and_push(dev_idx[0]);
-	std::cout << "Created a new context for device " << dev_idx[0] << " and pushed it onto the stack\n";
+	::std::cout << "Created a new context for device " << dev_idx[0] << " and pushed it onto the stack\n";
 	report_current_device();
 	assert_(cur_dev::get_id() == dev_idx[0]);
 	cur_ctx::push(ctx);
-	std::cout << "Pushed primary context handle for device " << dev_idx[0] << " onto the stack\n";
+	::std::cout << "Pushed primary context handle for device " << dev_idx[0] << " onto the stack\n";
 	report_current_device();
 	assert_(cur_dev::get_id() == dev_idx[0]);
 	cur_ctx::push(pc_handle[1]);
-	std::cout << "Pushed primary context for device " << dev_idx[1] << " onto the stack\n";
+	::std::cout << "Pushed primary context for device " << dev_idx[1] << " onto the stack\n";
 	report_current_device();
 	assert_(cur_dev::get_id() == dev_idx[1]);
 	pc::decrease_refcount(dev_idx[1]);
-	std::cout << "Deactivated/destroyed primary context for device " << dev_idx[1] << '\n';
+	::std::cout << "Deactivated/destroyed primary context for device " << dev_idx[1] << '\n';
 	report_current_device();
 	assert_(cur_dev::get_id() == dev_idx[1]);
 
-	std::cout << "\nSUCCESS" << std::endl;
+	::std::cout << "\nSUCCESS" << ::std::endl;
 }
 

--- a/examples/other/runtime_api_header_collection.cpp
+++ b/examples/other/runtime_api_header_collection.cpp
@@ -5,5 +5,5 @@
 int main()
 {
 	cuda::device::count();
-	std::cout << "SUCCESS\n";
+	::std::cout << "SUCCESS\n";
 }

--- a/examples/other/vectorAdd_profiled.cu
+++ b/examples/other/vectorAdd_profiled.cu
@@ -30,21 +30,21 @@ int main()
 	profile_this_scope();
 	cuda::profiling::name_this_thread("The single thread for vectorAdd_profile :-)");
 	if (cuda::device::count() == 0) {
-		std::cerr << "No CUDA devices on this system" << "\n";
+		::std::cerr << "No CUDA devices on this system" << "\n";
 		exit(EXIT_FAILURE);
 	}
 
 	int numElements = 500000;
 	size_t size = numElements * sizeof(float);
 
-	// If we could rely on C++14, we would  use std::make_unique
-	auto h_A = std::unique_ptr<float>(new float[numElements]);
-	auto h_B = std::unique_ptr<float>(new float[numElements]);
-	auto h_C = std::unique_ptr<float>(new float[numElements]);
+	// If we could rely on C++14, we would  use ::std::make_unique
+	auto h_A = ::std::unique_ptr<float>(new float[numElements]);
+	auto h_B = ::std::unique_ptr<float>(new float[numElements]);
+	auto h_C = ::std::unique_ptr<float>(new float[numElements]);
 
 	auto generator = []() { return rand() / (float) RAND_MAX; };
-	std::generate(h_A.get(), h_A.get() + numElements, generator);
-	std::generate(h_B.get(), h_B.get() + numElements, generator);
+	::std::generate(h_A.get(), h_A.get() + numElements, generator);
+	::std::generate(h_B.get(), h_B.get() + numElements, generator);
 
 	auto device = cuda::device::current::get();
 	auto d_A = cuda::memory::device::make_unique<float[]>(device, numElements);
@@ -57,7 +57,7 @@ int main()
 	// Launch the Vector Add CUDA Kernel
 	int threadsPerBlock = 256;
 	int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
-	std::cout
+	::std::cout
 		<< "CUDA kernel launch with " << blocksPerGrid
 		<< " blocks of " << threadsPerBlock << " threads\n";
 
@@ -68,6 +68,6 @@ int main()
 
 	cuda::memory::copy(h_C.get(), d_C.get(), size);
 
-	std::cout << "SUCCESS\n";
+	::std::cout << "SUCCESS\n";
 }
 

--- a/examples/zip.hpp
+++ b/examples/zip.hpp
@@ -10,18 +10,18 @@
  * Example:
 
 int main () {
-	std::vector<int> v1{1,2,3};
-	std::vector<int> v2{3,2,1};
-	std::vector<float> v3{1.2,2.4,9.0};
-	std::vector<float> v4{1.2,2.4,9.0};
-	std::cout << "Using zipped iterators:\n";
+	::std::vector<int> v1{1,2,3};
+	::std::vector<int> v2{3,2,1};
+	::std::vector<float> v3{1.2,2.4,9.0};
+	::std::vector<float> v4{1.2,2.4,9.0};
+	::std::cout << "Using zipped iterators:\n";
 	for_each_zipped([](int i,int j,float k,float l) {
-			std::cout << i << " " << j << " " << k << " " << l << '\n';
+			::std::cout << i << " " << j << " " << k << " " << l << '\n';
 		},
 		v1.begin(),v1.end(),v2.begin(),v3.begin(),v4.begin());
-	std::cout << "\nUsing zipped containers:\n";
+	::std::cout << "\nUsing zipped containers:\n";
 	for_each_zipped_containers([](int i,int j,float k,float l) {
-			std::cout << i << " " << j << " " << k << " " << l << '\n';
+			::std::cout << i << " " << j << " " << k << " " << l << '\n';
 		},
 		v1, v2, v3, v4);
 }
@@ -58,7 +58,7 @@ F for_each_zipped(F func, Iterator begin, Iterator end, ExtraIterators ... extra
 template <typename F, typename Container, typename... ExtraContainers>
 F for_each_zipped_containers(F func, Container& container, ExtraContainers& ... extra_containers)
 {
-	return for_each_zipped(func, std::begin(container), std::end(container), std::begin(extra_containers)...);
+	return for_each_zipped(func, ::std::begin(container), ::std::end(container), ::std::begin(extra_containers)...);
 }
 
 

--- a/src/cuda/api.hpp
+++ b/src/cuda/api.hpp
@@ -8,7 +8,9 @@
 #ifndef CUDA_API_WRAPPERS_HPP_
 #define CUDA_API_WRAPPERS_HPP_
 
-static_assert(__cplusplus >= 201103L, "The CUDA API headers can only be compiled with C++11 or a later version of the C++ language standard");
+#if (__cplusplus < 201103L && (!defined(_MSVC_LANG) || _MSVC_LANG < 201103L))
+#error "The CUDA API headers can only be compiled with C++11 or a later version of the C++ language standard"
+#endif
 
 #include <cuda/api/types.hpp>
 

--- a/src/cuda/api/array.hpp
+++ b/src/cuda/api/array.hpp
@@ -134,6 +134,9 @@ handle_t get_descriptor(context::handle_t context_handle, handle_t handle)
  * value, which is interpolated between the nearest corresponding array elements.
  *
  * @note CUDA only supports arrays of 2 or 3 dimensions.
+ *
+ * @note Instances of this class do _not_ keep devices' primary contexts
+ * alive/active - just like memory allocations (but unlike events and streams).
  */
 template <typename T, dimensionality_t NumDimensions>
 class array_t {
@@ -209,7 +212,7 @@ array_t<T,NumDimensions> create(
 
 template <typename T, dimensionality_t NumDimensions>
 array_t<T,NumDimensions> create(
-	device_t                     device,
+	const device_t&              device,
 	dimensions_t<NumDimensions>  dimensions);
 
 

--- a/src/cuda/api/constants.hpp
+++ b/src/cuda/api/constants.hpp
@@ -116,6 +116,11 @@ enum : bool {
 	do_not_take_ownership = false,
 };
 
+enum : bool {
+	do_hold_primary_context_refcount_unit = true,
+	do_not_hold_primary_context_refcount_unit = false,
+};
+
 namespace context {
 
 namespace detail_ {

--- a/src/cuda/api/context.hpp
+++ b/src/cuda/api/context.hpp
@@ -641,7 +641,7 @@ public: // constructors and destructor
 	~context_t() {
 		if (owning_) {
 			cuCtxDestroy(handle_);
-			// Note: "Swallowing" any potential error to avoid std::terminate(); also,
+			// Note: "Swallowing" any potential error to avoid ::std::terminate(); also,
 			// because the context cannot possibly exist after this call.
 		}
 	}

--- a/src/cuda/api/context.hpp
+++ b/src/cuda/api/context.hpp
@@ -244,8 +244,8 @@ public: // inner classes
 			: device_id_(device_id), context_handle_(context_handle) { }
 		///@endcond
 
-		device_t associated_device() const;
-		context_t associated_context() const;
+        device_t associated_device() const;
+        context_t associated_context() const;
 
 		/**
 		 * Allocate a region of memory on the device
@@ -385,7 +385,7 @@ public: // other non-mutator methods
 	/**
 	 * @return the maximum grid depth at which a thread can issue the device
 	 * runtime call `cudaDeviceSynchronize()` / `cuda::device::synchronize()`
-	 * to wait on child grid launches to complete.
+     * to wait on child grid launches to complete.
 	 *
 	 * @todo Is this really a feature of the context? Not of the device?
 	 */
@@ -661,7 +661,7 @@ public: // operators
 
 	// Deleted since the handle_t and handle_t are constant
 	context_t& operator=(context_t&& other) noexcept
-  	{
+	{
 		::std::swap(device_id_, other.device_id_);
 		::std::swap(handle_, other.handle_);
 		::std::swap(owning_, other.owning_);
@@ -741,12 +741,12 @@ inline handle_t create_and_push(
 context_t create(
 	device_t                               device,
 	host_thread_synch_scheduling_policy_t  synch_scheduling_policy = heuristic,
-	bool                                   keep_larger_local_mem_after_resize = false);
+    bool                                   keep_larger_local_mem_after_resize = false);
 
 context_t create_and_push(
 	device_t                               device,
 	host_thread_synch_scheduling_policy_t  synch_scheduling_policy = heuristic,
-	bool                                   keep_larger_local_mem_after_resize = false);
+    bool                                   keep_larger_local_mem_after_resize = false);
 
 namespace current {
 

--- a/src/cuda/api/context.hpp
+++ b/src/cuda/api/context.hpp
@@ -27,7 +27,7 @@ class module_t;
 ///@endcond
 
 namespace link {
-class options_t;
+struct options_t;
 } // namespace link
 
 namespace context {

--- a/src/cuda/api/device.hpp
+++ b/src/cuda/api/device.hpp
@@ -584,7 +584,7 @@ public: 	// constructors and destructor
 		maybe_decrease_primary_context_refcount();
 #else
 		if (holds_pc_refcount_unit)  {
-			cuDevicePrimaryCtxRelease(id_);
+			device::primary_context::detail_::decrease_refcount_nothrow(id_);
 				// Swallow any error to avoid termination on throwing from a dtor
 		}
 #endif

--- a/src/cuda/api/device.hpp
+++ b/src/cuda/api/device.hpp
@@ -64,7 +64,10 @@ namespace detail_ {
  * not explicitly construct contexts, to be able to function with a primary context
  * being made and kept active.
  */
-device_t wrap(id_t id, primary_context::handle_t primary_context_handle = context::detail_::none) noexcept;
+device_t wrap(
+	id_t id,
+	primary_context::handle_t primary_context_handle = context::detail_::none,
+	bool holds_primary_context_refcount_unit = false) noexcept;
 
 } // namespace detail
 
@@ -133,19 +136,22 @@ public: // types
 	using attribute_value_t = device::attribute_value_t;
 	using flags_type = device::flags_t;
 
-	// TODO: Consider a scoped/unscoped dichotomy
-	context_t::global_memory_type memory() const { return primary_context(unscoped_).memory(); }
+	/**
+	 *
+	 * @note The memory proxy regards the device's primary context.
+	 *
+	 * @todo Consider a scoped/unscoped dichotomy.
+	 */
+	context_t::global_memory_type memory() const {
+		return primary_context().memory();
+	}
 
 protected: // types
 	using context_setter_type = context::current::detail_::scoped_override_t;
 		// Note the context setter only affects the _currency_ of a context, not the
 		// activity of a primary context
 
-protected: // constants
-    enum : bool { scoped_ = true, unscoped_ = false };
-
 public:
-
 	/**
 	 * @brief Determine whether this device can access the global memory
 	 * of another CUDA device.
@@ -171,7 +177,7 @@ public:
 	 */
 	void enable_access_to(const device_t& peer) const
 	{
-		primary_context(scoped_).enable_access_to(peer.primary_context(scoped_));
+		primary_context().enable_access_to(peer.primary_context());
 	}
 
 	/**
@@ -181,7 +187,7 @@ public:
 	 */
 	void disable_access_to(const device_t& peer) const
 	{
-		primary_context(scoped_).disable_access_to(peer.primary_context(scoped_));
+		primary_context().disable_access_to(peer.primary_context());
 	}
 
 
@@ -198,7 +204,7 @@ protected:
 	void cache_and_ensure_primary_context_activation() const {
         if (primary_context_handle_ == context::detail_::none) {
             primary_context_handle_ = device::primary_context::detail_::obtain_and_increase_refcount(id_);
-            // The refcount should now be non-zero until we destruct this device_t!
+			holds_pc_refcount_unit = true;
         }
 	}
 
@@ -218,18 +224,7 @@ public:
 	 * this device object exists. When false, the returned primary context proxy object
 	 * _will_ take care of its own reference count unit, and can outlive this object.
 	 */
-	device::primary_context_t primary_context(bool scoped) const;
-
-
-public:
-	/**
-	 * Produce a proxy for the device's primary context - the one used by runtime API calls.
-	 *
-	 * @note The CUDA driver reference counting for the primary scope is "taken core of"
-	 * with this call, i.e. the caller does not need to add/decrease the refcount, and the
-	 * object can safely outlive the device_t proxy object which created it.
-	 */
-	device::primary_context_t primary_context() const { return primary_context(unscoped_); }
+	device::primary_context_t primary_context(bool hold_pc_refcount_unit = false) const;
 
 	void set_flags(flags_type new_flags) const
 	{
@@ -368,7 +363,7 @@ public:
 	 */
 	device::limit_value_t get_limit(device::limit_t limit) const
 	{
-		return primary_context(scoped_).get_limit(limit);
+		return primary_context().get_limit(limit);
 	}
 
 	/**
@@ -377,7 +372,7 @@ public:
 	 */
 	void set_limit(device::limit_t limit, device::limit_value_t new_value) const
 	{
-		primary_context(scoped_).set_limit(limit, new_value);
+		primary_context().set_limit(limit, new_value);
 	}
 
 	/**
@@ -445,7 +440,7 @@ public:
 	 */
 	void set_cache_preference(multiprocessor_cache_preference_t preference) const
 	{
-		primary_context(scoped_).set_cache_preference(preference);
+		primary_context().set_cache_preference(preference);
 	}
 
 	/**
@@ -454,7 +449,7 @@ public:
 	 */
 	multiprocessor_cache_preference_t cache_preference() const
 	{
-		return primary_context(scoped_).cache_preference();
+		return primary_context().cache_preference();
 	}
 
 	/**
@@ -465,7 +460,7 @@ public:
 	 */
 	void set_shared_memory_bank_size(device::shared_memory_bank_size_t new_bank_size) const
 	{
-		primary_context(scoped_).set_shared_memory_bank_size(new_bank_size);
+		primary_context().set_shared_memory_bank_size(new_bank_size);
 	}
 
 	/**
@@ -476,7 +471,7 @@ public:
 	 */
 	device::shared_memory_bank_size_t shared_memory_bank_size() const
 	{
-		return primary_context(scoped_).shared_memory_bank_size();
+		return primary_context().shared_memory_bank_size();
 	}
 
 	// For some reason, there is no cudaFuncGetCacheConfig. Weird.
@@ -494,7 +489,7 @@ public:
 		return id_;
 	}
 
-	stream_t default_stream() const;
+	stream_t default_stream(bool hold_primary_context_refcount_unit = false) const;
 
 	/**
 	 * See @ref cuda::stream::create()
@@ -530,7 +525,7 @@ public:
 	 */
 	device::stream_priority_range_t stream_priority_range() const
 	{
-		return primary_context(scoped_).stream_priority_range();
+		return primary_context().stream_priority_range();
 	}
 
 public:
@@ -570,7 +565,7 @@ public:
 protected:
 	void maybe_decrease_primary_context_refcount() const
 	{
-		if (primary_context_handle_ != context::detail_::none) {
+		if (holds_pc_refcount_unit) {
 			device::primary_context::detail_::decrease_refcount(id_);
 		}
 	}
@@ -581,8 +576,20 @@ public: 	// constructors and destructor
 	{
 		::std::swap(lhs.id_, rhs.id_);
 		::std::swap(lhs.primary_context_handle_, rhs.primary_context_handle_);
+		::std::swap(lhs.holds_pc_refcount_unit, rhs.holds_pc_refcount_unit);
 	}
-	~device_t() { maybe_decrease_primary_context_refcount(); }
+
+	~device_t() {
+#ifndef NDEBUG
+		maybe_decrease_primary_context_refcount();
+#else
+		if (holds_pc_refcount_unit)  {
+			cuDevicePrimaryCtxRelease(id_);
+				// Swallow any error to avoid termination on throwing from a dtor
+		}
+#endif
+	}
+
 	device_t(device_t&& other) noexcept : id_(other.id_)
 	{
 		swap(*this, other);
@@ -601,6 +608,7 @@ public: 	// constructors and destructor
 		maybe_decrease_primary_context_refcount();
 		id_ = other.id_;
 		primary_context_handle_ = other.primary_context_handle_;
+		holds_pc_refcount_unit = false;
 		return *this;
 	}
 
@@ -618,17 +626,27 @@ protected: // constructors
 	 */
 	explicit device_t(
 		device::id_t device_id,
-		device::primary_context::handle_t primary_context_handle = context::detail_::none) noexcept
-	: id_(device_id), primary_context_handle_(primary_context_handle) { }
+		device::primary_context::handle_t primary_context_handle = context::detail_::none,
+		bool hold_primary_context_refcount_unit = false) noexcept
+	:
+		id_(device_id),
+		primary_context_handle_(primary_context_handle),
+		holds_pc_refcount_unit(hold_primary_context_refcount_unit) { }
 
 public: // friends
-	friend device_t device::detail_::wrap(device::id_t, device::primary_context::handle_t handle) noexcept;
+	friend device_t device::detail_::wrap(
+		device::id_t,
+		device::primary_context::handle_t handle,
+		bool hold_primary_context_refcount_unit) noexcept;
 
 protected: // data members
 	device::id_t id_; /// Numeric ID of the proxied device.
 	mutable device::primary_context::handle_t primary_context_handle_ { context::detail_::none };
 		/// Most work involving a device actually occurs using its primary context; we cache the handle
 		/// to this context here - albeit not necessary on construction
+	mutable bool holds_pc_refcount_unit { false };
+		/// Since we're allowed to cache the primary context handle on constant device_t's, we
+		/// also need to keep track of whether this object "owns" this reference.
 };
 
 ///@cond
@@ -647,9 +665,12 @@ namespace device {
 
 namespace detail_ {
 
-inline device_t wrap(id_t id, primary_context::handle_t primary_context_handle) noexcept
+inline device_t wrap(
+	id_t id,
+	primary_context::handle_t primary_context_handle,
+	bool hold_primary_context_refcount_unit) noexcept
 {
-	return device_t{ id, primary_context_handle };
+	return device_t{ id, primary_context_handle, hold_primary_context_refcount_unit };
 }
 
 } // namespace detail_
@@ -694,10 +715,11 @@ inline device_t get()
 	return device::detail_::wrap(id, pc_handle);
 }
 
-/**
- * Tells the CUDA runtime API to consider the specified device as the current one.
- */
-inline void set(const device_t& device) { detail_::set(device.id()); }
+inline void set(const device_t& device)
+{
+	auto pc = device.primary_context();
+	context::current::detail_::set(pc.handle());
+}
 
 } // namespace current
 

--- a/src/cuda/api/error.hpp
+++ b/src/cuda/api/error.hpp
@@ -469,7 +469,7 @@ inline ::std::string identify(handle_t handle, device::id_t device_id)
 
 } // namespace detail_
 
-namespace current{
+namespace current {
 namespace detail_ {
 inline ::std::string identify(context::handle_t handle)
 {

--- a/src/cuda/api/error.hpp
+++ b/src/cuda/api/error.hpp
@@ -227,7 +227,7 @@ inline ::std::string describe(cudaError_t status) { return cudaGetErrorString(st
 namespace detail_ {
 
 template <typename I, bool UpperCase = false>
-std::string as_hex(I x)
+::std::string as_hex(I x)
 {
 	static_assert(::std::is_unsigned<I>::value, "only signed representations are supported");
 	unsigned num_hex_digits = 2*sizeof(I);

--- a/src/cuda/api/event.hpp
+++ b/src/cuda/api/event.hpp
@@ -264,7 +264,7 @@ public: // constructors and destructor
 		if (owning) {
 #ifdef NDEBUG
 			cuEventDestroy(handle_);
-				// Note: "Swallowing" any potential error to avoid std::terminate(); also,
+				// Note: "Swallowing" any potential error to avoid ::std::terminate(); also,
 				// because the event cannot possibly exist after this call.
 #else
 			event::detail_::destroy(handle_, device_id_, context_handle_);
@@ -274,7 +274,7 @@ public: // constructors and destructor
 		if (holds_pc_refcount_unit) {
 #ifdef NDEBUG
 			device::primary_context::detail_::decrease_refcount_nothrow(device_id_);
-				// Note: "Swallowing" any potential error to avoid std::terminate(); also,
+				// Note: "Swallowing" any potential error to avoid ::std::terminate(); also,
 				// because a failure probably means the primary context is inactive already
 #else
 			device::primary_context::detail_::decrease_refcount(device_id_);

--- a/src/cuda/api/event.hpp
+++ b/src/cuda/api/event.hpp
@@ -30,6 +30,11 @@ namespace event {
 
 namespace detail_ {
 
+inline void destroy(
+	handle_t           handle,
+	device::id_t       device_id,
+	context::handle_t  context_handle);
+
 inline void enqueue_in_current_context(stream::handle_t stream_handle, handle_t event_handle)
 {
 	auto status = cuEventRecord(event_handle, stream_handle);
@@ -90,7 +95,8 @@ event_t wrap(
 	device::id_t       device_id,
 	context::handle_t  context_handle,
 	handle_t           event_handle,
-	bool               take_ownership = false) noexcept;
+	bool               take_ownership = false,
+	bool               hold_pc_refcount_unit = false) noexcept;
 
 ::std::string identify(const event_t& event);
 
@@ -128,6 +134,10 @@ public: // data member non-mutator getters
 
 	/// True if this wrapper is responsible for telling CUDA to destroy the event upon the wrapper's own destruction
 	bool              is_owning()       const noexcept { return owning; }
+
+	/// True if this wrapper has been associated with an increase of the device's primary context's reference count
+	bool              holds_primary_context_reference()
+	                                    const noexcept { return holds_pc_refcount_unit; }
 
 	/// The device w.r.t. which the event is defined
 	device_t          device()          const;
@@ -207,29 +217,68 @@ public: // other mutator methods
 
 protected: // constructors
 
-	event_t(device::id_t device_id, context::handle_t context_handle, event::handle_t event_handle, bool take_ownership) noexcept
-	: device_id_(device_id), context_handle_(context_handle), handle_(event_handle), owning(take_ownership) { }
+	event_t(
+		device::id_t device_id,
+		context::handle_t context_handle,
+		event::handle_t event_handle,
+		bool take_ownership,
+		bool hold_pc_refcount_unit) noexcept
+	:
+		device_id_(device_id),
+		context_handle_(context_handle),
+		handle_(event_handle),
+		owning(take_ownership),
+		holds_pc_refcount_unit(hold_pc_refcount_unit) { }
 
 public: // friendship
 
-	friend event_t event::wrap(device::id_t, context::handle_t context_handle, event::handle_t event_handle, bool take_ownership) noexcept;
+	friend event_t event::wrap(
+		device::id_t       device,
+		context::handle_t  context_handle,
+		event::handle_t    event_handle,
+		bool               take_ownership,
+		bool               hold_pc_refcount_unit) noexcept;
 
 public: // constructors and destructor
 
-	event_t(const event_t& other) noexcept : event_t(other.device_id_, other.context_handle_, other.handle_, false) { }
+	// Copying is allowed, but is only shallow, as otherwise,
+	// an actual new event would need to be created, and we want that to
+	// be explicit
 
-	event_t(event_t&& other) noexcept :
-		event_t(other.device_id_, other.context_handle_, other.handle_, other.owning)
+	event_t(const event_t& other) noexcept : event_t(
+		other.device_id_,
+		other.context_handle_,
+		other.handle_,
+		do_not_take_ownership,
+		do_not_hold_primary_context_refcount_unit) { }
+
+	event_t(event_t&& other) noexcept : event_t(
+		other.device_id_, other.context_handle_, other.handle_, other.owning, other.holds_pc_refcount_unit)
 	{
 		other.owning = false;
+		other.holds_pc_refcount_unit = false;
 	};
 
 	~event_t()
 	{
 		if (owning) {
+#ifdef NDEBUG
 			cuEventDestroy(handle_);
 				// Note: "Swallowing" any potential error to avoid std::terminate(); also,
-				// because the context cannot possibly exist after this call.
+				// because the event cannot possibly exist after this call.
+#else
+			event::detail_::destroy(handle_, device_id_, context_handle_);
+#endif
+		}
+		// TODO: DRY
+		if (holds_pc_refcount_unit) {
+#ifdef NDEBUG
+			cuDevicePrimaryCtxRelease(device_id_);
+				// Note: "Swallowing" any potential error to avoid std::terminate(); also,
+				// because a failure probably means the primary context is inactive already
+#else
+			device::primary_context::detail_::decrease_refcount(device_id_);
+#endif
 		}
 	}
 
@@ -245,6 +294,10 @@ protected: // data members
 	bool                     owning;
 		// this field is mutable only for enabling move construction; other
 		// than in that case it must not be altered
+	bool                     holds_pc_refcount_unit;
+		// When context_handle_ is the handle of a primary context, this event may
+		// be "keeping that context alive" through the refcount - in which case
+		// it must release its refcount unit on destruction
 };
 
 namespace event {
@@ -277,9 +330,10 @@ inline event_t wrap(
 	device::id_t       device_id,
 	context::handle_t  context_handle,
 	handle_t           event_handle,
-	bool               take_ownership) noexcept
+	bool               take_ownership,
+	bool               hold_pc_refcount_unit) noexcept
 {
-	return { device_id, context_handle, event_handle, take_ownership };
+	return { device_id, context_handle, event_handle, take_ownership, hold_pc_refcount_unit };
 }
 
 namespace detail_ {
@@ -297,19 +351,33 @@ inline handle_t create_raw_in_current_context(flags_t flags = 0u)
 	return new_event_handle;
 }
 
-// Note: For now, event_t's need their device's ID - even if it's the current device;
-// that explains the requirement in this function's interface
+// Notes:
+// * For now, event_t's need their device's ID - even if it's the current device;
+//   that explains the requirement in this function's interface.
+// * Similarly, this function does not know whether the context is primary or
+//   not, and it is up to the caller to know that and decide whether the event
+//   proxy should decrease the primary context refcount on destruction
 inline event_t create_in_current_context(
 	device::id_t       current_device_id,
 	context::handle_t  current_context_handle,
+	bool               hold_pc_refcount_unit,
 	bool               uses_blocking_sync,
 	bool               records_timing,
 	bool               interprocess)
 {
 	auto flags = make_flags(uses_blocking_sync, records_timing, interprocess);
 	auto new_event_handle = create_raw_in_current_context(flags);
-	bool take_ownership = true;
-	return wrap(current_device_id, current_context_handle, new_event_handle, take_ownership);
+	return wrap(current_device_id, current_context_handle, new_event_handle, do_take_ownership, hold_pc_refcount_unit);
+}
+
+inline void destroy_in_current_context(
+	handle_t           handle,
+	device::id_t       current_device_id,
+	context::handle_t  current_context_handle)
+{
+	auto status = cuEventDestroy(handle);
+	cuda::throw_if_error(status, "Failed destroying " +
+		identify(handle, current_context_handle, current_device_id));
 }
 
 /**
@@ -319,18 +387,32 @@ inline event_t create_in_current_context(
 inline event_t create(
 	device::id_t       device_id,
 	context::handle_t  context_handle,
+	bool               hold_pc_refcount_unit,
 	bool               uses_blocking_sync,
 	bool               records_timing,
 	bool               interprocess)
 {
 	context::current::detail_::scoped_override_t set_context_for_this_scope(context_handle);
-	return detail_::create_in_current_context(device_id, context_handle, uses_blocking_sync, records_timing, interprocess);
+
+	return detail_::create_in_current_context(
+		device_id, context_handle,
+		hold_pc_refcount_unit,
+		uses_blocking_sync, records_timing, interprocess);
+}
+
+inline void destroy(
+	handle_t           handle,
+	device::id_t       device_id,
+	context::handle_t  context_handle)
+{
+	context::current::detail_::scoped_override_t set_context_for_this_scope(context_handle);
+	destroy_in_current_context(handle, device_id, context_handle);
 }
 
 } // namespace detail_
 
 /**
- * @brief creates a new execution stream on a device.
+ * @brief creates a new event on (the primary execution context of) a device.
  *
  * @param device              The device on which to create the new stream
  * @param uses_blocking_sync  When synchronizing on this new event, shall a thread busy-wait for it, or block?
@@ -338,13 +420,30 @@ inline event_t create(
  * @param interprocess        Can multiple processes work with the constructed event?
  * @return The constructed event proxy
  *
- * @note Creating an event
+ * @note The created event will keep the device's primary context active while it exists.
  */
 inline event_t create(
-	device_t&  device,
-	bool       uses_blocking_sync = sync_by_busy_waiting, // Yes, that's the runtime default
-	bool       records_timing     = do_record_timings,
-	bool       interprocess       = not_interprocess);
+	const device_t&  device,
+	bool             uses_blocking_sync = sync_by_busy_waiting, // Yes, that's the runtime default
+	bool             records_timing     = do_record_timings,
+	bool             interprocess       = not_interprocess);
+
+/**
+ * @brief creates a new event.
+ *
+ * @param context             The CUDA execution context in which to create the event
+ * @param uses_blocking_sync  When synchronizing on this new event, shall a thread busy-wait for it, or block?
+ * @param records_timing      Can this event be used to record time values (e.g. duration between events)?
+ * @param interprocess        Can multiple processes work with the constructed event?
+ * @return The constructed event proxy
+ *
+ * @note Even if the context happens to be primary, the created event will _not_ keep this context alive.
+ */
+inline event_t create(
+	context_t&  context,
+	bool        uses_blocking_sync = sync_by_busy_waiting,
+	bool        records_timing     = do_record_timings,
+	bool        interprocess       = not_interprocess);
 
 } // namespace event
 

--- a/src/cuda/api/event.hpp
+++ b/src/cuda/api/event.hpp
@@ -273,7 +273,7 @@ public: // constructors and destructor
 		// TODO: DRY
 		if (holds_pc_refcount_unit) {
 #ifdef NDEBUG
-			cuDevicePrimaryCtxRelease(device_id_);
+			device::primary_context::detail_::decrease_refcount_nothrow(device_id_);
 				// Note: "Swallowing" any potential error to avoid std::terminate(); also,
 				// because a failure probably means the primary context is inactive already
 #else

--- a/src/cuda/api/kernel.hpp
+++ b/src/cuda/api/kernel.hpp
@@ -35,7 +35,7 @@ class kernel_t;
 
 namespace kernel {
 
-using shared_memory_size_determiner_t = size_t (*)(int block_size);
+using shared_memory_size_determiner_t = size_t (CUDA_CB *)(int block_size);
 
 /**
  * Obtain a proxy object for a CUDA kernel

--- a/src/cuda/api/kernel.hpp
+++ b/src/cuda/api/kernel.hpp
@@ -346,7 +346,7 @@ public: // ctors & dtor
 		// TODO: DRY
 		if (holds_pc_refcount_unit) {
 #ifdef NDEBUG
-			cuDevicePrimaryCtxRelease(device_id_);
+			device::primary_context::detail_::decrease_refcount_nothrow(device_id_);
 				// Note: "Swallowing" any potential error to avoid std::terminate(); also,
 				// because a failure probably means the primary context is inactive already
 #else

--- a/src/cuda/api/link.hpp
+++ b/src/cuda/api/link.hpp
@@ -13,7 +13,7 @@
 #include <cuda/api/module.hpp>
 #include <cuda.h>
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 #include <filesystem>
 #endif
 
@@ -118,7 +118,7 @@ public:
 			"Failed loading an object of type " + ::std::to_string(file_input.type) + " from file " + file_input.path);
 	}
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 	void add_file(const ::std::filesystem::path& path, link::input_type_t file_contents_type) const
 	{
 		return add_file(path.c_str(), file_contents_type);

--- a/src/cuda/api/link_options.hpp
+++ b/src/cuda/api/link_options.hpp
@@ -235,7 +235,6 @@ struct options_t {
 	//   CU_JIT_GLOBAL_SYMBOL_COUNT
 	//
 
-public:
 	marshalled_options_t marshal() const;
 };
 

--- a/src/cuda/api/memory.hpp
+++ b/src/cuda/api/memory.hpp
@@ -173,7 +173,7 @@ namespace detail_ {
  */
 inline region_t allocate(
 	context::handle_t  context_handle,
-	stream::handle_t       stream_handle,
+	stream::handle_t   stream_handle,
 	size_t             num_bytes)
 {
 #if CUDA_VERSION >= 11020

--- a/src/cuda/api/memory.hpp
+++ b/src/cuda/api/memory.hpp
@@ -1781,7 +1781,7 @@ inline advice_t as_advice(range_attribute_t attribute, bool set)
 	case CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY:
 		return set ? CU_MEM_ADVISE_SET_ACCESSED_BY : CU_MEM_ADVISE_UNSET_ACCESSED_BY;
 	default:
-		throw std::invalid_argument(
+		throw ::std::invalid_argument(
 			"CUDA memory range attribute does not correspond to any range advice value");
 	}
 }
@@ -2170,9 +2170,9 @@ inline memory::region_t locate(T&& symbol)
 {
 	void *start;
 	size_t symbol_size;
-	auto api_call_result = cudaGetSymbolAddress(&start, std::forward<T>(symbol));
+	auto api_call_result = cudaGetSymbolAddress(&start, ::std::forward<T>(symbol));
 	throw_if_error(api_call_result, "Could not locate the device memory address for a symbol");
-	api_call_result = cudaGetSymbolSize(&symbol_size, std::forward<T>(symbol));
+	api_call_result = cudaGetSymbolSize(&symbol_size, ::std::forward<T>(symbol));
 	throw_if_error(api_call_result, "Could not locate the device memory address for the symbol at address"
 		+ cuda::detail_::ptr_as_hex(start));
 	return { start, symbol_size };

--- a/src/cuda/api/memory.hpp
+++ b/src/cuda/api/memory.hpp
@@ -229,7 +229,7 @@ inline void free(void* ptr)
 #else
 	if (result == status::success or result == status::context_is_destroyed) { return; }
 #endif
-	throw runtime_error(result, "Freeing device memory at 0x" + cuda::detail_::ptr_as_hex(ptr));
+	throw runtime_error(result, "Freeing device memory at " + cuda::detail_::ptr_as_hex(ptr));
 }
 inline void free(region_t region) { free(region.start()); }
 ///@}
@@ -1847,7 +1847,7 @@ inline void free(void* ptr)
 {
 	auto result = cuMemFree(device::address(ptr));
 	cuda::device::primary_context::detail_::decrease_refcount(cuda::device::default_device_id);
-	throw_if_error(result, "Freeing managed memory at 0x" + cuda::detail_::ptr_as_hex(ptr));
+	throw_if_error(result, "Freeing managed memory at " + cuda::detail_::ptr_as_hex(ptr));
 }
 inline void free(region_t region)
 {
@@ -1935,7 +1935,7 @@ inline void free(void* managed_ptr)
 {
 	auto result = cuMemFree(device::address(managed_ptr));
 	throw_if_error(result,
-		"Freeing managed memory (host and device regions) at address 0x"
+		"Freeing managed memory (host and device regions) at address "
 		+ cuda::detail_::ptr_as_hex(managed_ptr));
 }
 

--- a/src/cuda/api/memory.hpp
+++ b/src/cuda/api/memory.hpp
@@ -1509,7 +1509,6 @@ inline void* allocate(size_t size_in_bytes, cpu_write_combining cpu_wc)
  */
 inline void free(void* host_ptr)
 {
-	cuda::device::primary_context::detail_::decrease_refcount(cuda::device::default_device_id);
 	auto result = cuMemFreeHost(host_ptr);
 #if CAW_THROW_ON_FREE_IN_DESTROYED_CONTEXT
 	if (result == status::success) { return; }

--- a/src/cuda/api/memory.hpp
+++ b/src/cuda/api/memory.hpp
@@ -306,7 +306,7 @@ inline void typed_set(T* start, const T& value, size_t num_elements);
  */
 inline void set(void* start, int byte_value, size_t num_bytes)
 {
-	return typed_set<unsigned char>(static_cast<unsigned char*>(start), byte_value, num_bytes);
+	return typed_set<unsigned char>(static_cast<unsigned char*>(start), (unsigned char) byte_value, num_bytes);
 }
 
 /**
@@ -1201,7 +1201,7 @@ namespace detail_ {
 inline void set(void* start, int byte_value, size_t num_bytes, stream::handle_t stream_handle)
 {
 	// TODO: Double-check that this call doesn't require setting the current device
-	auto result = cuMemsetD8Async(address(start), byte_value, num_bytes, stream_handle);
+	auto result = cuMemsetD8Async(address(start), (unsigned char) byte_value, num_bytes, stream_handle);
 	throw_if_error(result, "asynchronously memsetting an on-device buffer");
 }
 
@@ -1270,7 +1270,7 @@ void typed_set(T* start, const T& value, size_t num_elements, const stream_t& st
  */
 inline void set(void* start, int byte_value, size_t num_bytes, const stream_t& stream)
 {
-	return typed_set<unsigned char>(static_cast<unsigned char*>(start), byte_value, num_bytes, stream);
+	return typed_set<unsigned char>(static_cast<unsigned char*>(start), (unsigned char) byte_value, num_bytes, stream);
 }
 
 /**

--- a/src/cuda/api/module.hpp
+++ b/src/cuda/api/module.hpp
@@ -175,7 +175,7 @@ public: // constructors and destructor
 		// TODO: DRY
 		if (holds_pc_refcount_unit) {
 #ifdef NDEBUG
-			cuDevicePrimaryCtxRelease(device_id_);
+			device::primary_context::detail_::decrease_refcount_nothrow(device_id_);
 				// Note: "Swallowing" any potential error to avoid std::terminate(); also,
 				// because a failure probably means the primary context is inactive already
 #else

--- a/src/cuda/api/module.hpp
+++ b/src/cuda/api/module.hpp
@@ -16,7 +16,7 @@
 #include <cuda.h>
 #include <array>
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 #include <filesystem>
 #endif
 
@@ -297,7 +297,7 @@ inline module_t load_from_file(
 }
 
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 
 inline module_t load_from_file(
 	const device_t&                 device,

--- a/src/cuda/api/module.hpp
+++ b/src/cuda/api/module.hpp
@@ -45,7 +45,7 @@ inline module_t construct(
 
 inline ::std::string identify(const module::handle_t &handle)
 {
-	return std::string("module ") + cuda::detail_::ptr_as_hex(handle);
+	return ::std::string("module ") + cuda::detail_::ptr_as_hex(handle);
 }
 
 inline ::std::string identify(const module::handle_t &handle, context::handle_t context_handle)
@@ -176,7 +176,7 @@ public: // constructors and destructor
 		if (holds_pc_refcount_unit) {
 #ifdef NDEBUG
 			device::primary_context::detail_::decrease_refcount_nothrow(device_id_);
-				// Note: "Swallowing" any potential error to avoid std::terminate(); also,
+				// Note: "Swallowing" any potential error to avoid ::std::terminate(); also,
 				// because a failure probably means the primary context is inactive already
 #else
 			device::primary_context::detail_::decrease_refcount(device_id_);
@@ -243,7 +243,7 @@ inline module_t load_from_file_in_current_context(
  *
  * @todo: consider adding load_module methods to context_t
  * @todo: When switching to the C++17 standard, use string_view's instead of the const char*
- * and std::string reference
+ * and ::std::string reference
  */
 ///@{
 inline module_t load_from_file(

--- a/src/cuda/api/module.hpp
+++ b/src/cuda/api/module.hpp
@@ -40,7 +40,8 @@ inline module_t construct(
 	context::handle_t context_handle,
 	handle_t handle,
 	link::options_t options,
-	bool take_ownership = false) noexcept;
+	bool take_ownership = false,
+	bool holds_primary_context_refcount_unit = false) noexcept;
 
 inline ::std::string identify(const module::handle_t &handle)
 {
@@ -80,11 +81,12 @@ module_t create(
 	Locus&&              locus,
 	ContiguousContainer  module_data,
 	link::options_t      link_options);
+
 template <typename Locus, typename ContiguousContainer,
 	cuda::detail_::enable_if_t<cuda::detail_::is_kinda_like_contiguous_container<ContiguousContainer>::value, bool> = true >
 module_t create(
 	Locus&&          locus,
-ContiguousContainer  module_data);
+	ContiguousContainer  module_data);
 ///@}
 
 } // namespace module
@@ -103,6 +105,7 @@ public: // getters
 	context::handle_t context_handle() const { return context_handle_; }
 	device::id_t device_id() const { return device_id_; }
 	context_t context() const;
+
 	device_t device() const;
 
 	// These API calls are not really the way you want to work.
@@ -129,14 +132,17 @@ protected: // constructors
 		context::handle_t context,
 		module::handle_t handle,
 		link::options_t options,
-		bool owning)
-		noexcept
-		: device_id_(device_id), context_handle_(context), handle_(handle), options_(options), owning_(owning)
+		bool owning,
+		bool holds_primary_context_refcount_unit)
+	noexcept
+		: device_id_(device_id), context_handle_(context), handle_(handle), options_(options), owning_(owning),
+		  holds_pc_refcount_unit(holds_primary_context_refcount_unit)
 	{ }
 
 public: // friendship
 
-	friend module_t module::detail_::construct(device::id_t, context::handle_t, module::handle_t, link::options_t, bool) noexcept;
+	friend module_t module::detail_::construct(
+		device::id_t, context::handle_t, module::handle_t, link::options_t, bool, bool) noexcept;
 
 
 public: // constructors and destructor
@@ -144,9 +150,16 @@ public: // constructors and destructor
 	module_t(const module_t&) = delete;
 
 	module_t(module_t&& other) noexcept :
-		module_t(other.device_id_, other.context_handle_, other.handle_, other.options_, other.owning_)
+		module_t(
+			other.device_id_,
+			other.context_handle_,
+			other.handle_,
+			other.options_,
+			other.owning_,
+			other.holds_pc_refcount_unit)
 	{
 		other.owning_ = false;
+		other.holds_pc_refcount_unit = false;
 	};
 
 	// Note: It is up to the user of this class to ensure that it is destroyed _before_ the context
@@ -157,7 +170,17 @@ public: // constructors and destructor
 		if (owning_) {
 			context::current::detail_::scoped_override_t set_context_for_this_scope(context_handle_);
 			auto status = cuModuleUnload(handle_);
-		 	throw_if_error(status, "Failed unloading " + module::detail_::identify(*this));
+			throw_if_error(status, "Failed unloading " + module::detail_::identify(*this));
+		}
+		// TODO: DRY
+		if (holds_pc_refcount_unit) {
+#ifdef NDEBUG
+			cuDevicePrimaryCtxRelease(device_id_);
+				// Note: "Swallowing" any potential error to avoid std::terminate(); also,
+				// because a failure probably means the primary context is inactive already
+#else
+			device::primary_context::detail_::decrease_refcount(device_id_);
+#endif
 		}
 	}
 
@@ -174,6 +197,10 @@ protected: // data members
 	bool               owning_;
 		// this field is mutable only for enabling move construction; other
 		// than in that case it must not be altered
+	bool holds_pc_refcount_unit;
+		// When context_handle_ is the handle of a primary context, this module
+		// may be "keeping that context alive" through the refcount - in which
+		// case it must release its refcount unit on destruction
 };
 
 namespace module {
@@ -186,7 +213,8 @@ inline module_t load_from_file_in_current_context(
 	device::id_t current_context_device_id,
 	context::handle_t current_context_handle,
 	const char *path,
-	link::options_t link_options)
+	link::options_t link_options,
+	bool holds_primary_context_refcount_unit = false)
 {
 	handle_t new_module_handle;
 	auto status = cuModuleLoad(&new_module_handle, path);
@@ -197,7 +225,8 @@ inline module_t load_from_file_in_current_context(
 		current_context_handle,
 		new_module_handle,
 		link_options,
-		do_take_ownership);
+		do_take_ownership,
+		holds_primary_context_refcount_unit);
 }
 
 } // namespace detail_
@@ -297,9 +326,11 @@ inline module_t construct(
 	context::handle_t context_handle,
 	handle_t module_handle,
 	link::options_t options,
-	bool take_ownership) noexcept
+	bool take_ownership,
+	bool hold_pc_refcount_unit
+) noexcept
 {
-	return module_t{device_id, context_handle, module_handle, options, take_ownership};
+	return module_t{device_id, context_handle, module_handle, options, take_ownership, hold_pc_refcount_unit};
 }
 
 template <typename Creator>
@@ -351,7 +382,7 @@ inline device::primary_context_t get_context_for(device_t& locus);
 // Note: The following may create the primary context of a device!
 template <typename Locus, typename ContiguousContainer,
 	cuda::detail_::enable_if_t<cuda::detail_::is_kinda_like_contiguous_container<ContiguousContainer>::value, bool>>
-module_t  create(
+module_t create(
 	Locus&&  locus,
 	ContiguousContainer module_data)
 {

--- a/src/cuda/api/multi_wrapper_impls/apriori_compiled_kernel.hpp
+++ b/src/cuda/api/multi_wrapper_impls/apriori_compiled_kernel.hpp
@@ -76,8 +76,8 @@ inline void apriori_compiled_kernel_t::set_attribute(kernel::attribute_t attribu
 				return cudaFuncAttributePreferredSharedMemoryCarveout;
 			default:
 				throw cuda::runtime_error(status::not_supported,
-					"Kernel attribute " + std::to_string(attribute) + " not supported (with CUDA version "
-					+ std::to_string(CUDA_VERSION));
+					"Kernel attribute " + ::std::to_string(attribute) + " not supported (with CUDA version "
+					+ ::std::to_string(CUDA_VERSION));
 		}
 	}();
 	auto result = cudaFuncSetAttribute(ptr_, runtime_attribute, value);

--- a/src/cuda/api/multi_wrapper_impls/apriori_compiled_kernel.hpp
+++ b/src/cuda/api/multi_wrapper_impls/apriori_compiled_kernel.hpp
@@ -37,7 +37,8 @@ namespace cuda {
 
 inline kernel::attributes_t apriori_compiled_kernel_t::attributes() const
 {
-	device::current::detail_::scoped_context_override_t set_device_for_this_scope(device_id_);
+	// Note: assuming the primary context is active
+	context::current::detail_::scoped_override_t set_context_for_this_scope(context_handle_);
 	kernel::attributes_t function_attributes;
 	auto status = cudaFuncGetAttributes(&function_attributes, ptr_);
 	throw_if_error(status, "Failed obtaining attributes for a CUDA device function");
@@ -46,7 +47,8 @@ inline kernel::attributes_t apriori_compiled_kernel_t::attributes() const
 
 inline void apriori_compiled_kernel_t::set_cache_preference(multiprocessor_cache_preference_t preference) const
 {
-	device::current::detail_::scoped_context_override_t set_device_for_this_scope(device_id_);
+	// Note: assuming the primary context is active
+	context::current::detail_::scoped_override_t set_context_for_this_scope(context_handle_);
 	auto result = cudaFuncSetCacheConfig(ptr_, (cudaFuncCache) preference);
 	throw_if_error(result,
 		"Setting the multiprocessor L1/Shared Memory cache distribution preference for a "
@@ -56,14 +58,16 @@ inline void apriori_compiled_kernel_t::set_cache_preference(multiprocessor_cache
 inline void apriori_compiled_kernel_t::set_shared_memory_bank_size(
 	multiprocessor_shared_memory_bank_size_option_t  config) const
 {
-	device::current::detail_::scoped_context_override_t set_device_for_this_scope(device_id_);
+	// Note: assuming the primary context is active
+	context::current::detail_::scoped_override_t set_context_for_this_scope(context_handle_);
 	auto result = cudaFuncSetSharedMemConfig(ptr_, (cudaSharedMemConfig) config);
 	throw_if_error(result);
 }
 
 inline void apriori_compiled_kernel_t::set_attribute(kernel::attribute_t attribute, kernel::attribute_value_t value) const
 {
-	device::current::detail_::scoped_context_override_t set_device_for_this_scope(device_id_);
+	// Note: assuming the primary context is active
+	context::current::detail_::scoped_override_t set_context_for_this_scope(context_handle_);
 	cudaFuncAttribute runtime_attribute = [attribute]() {
 		switch (attribute) {
 			case CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES:

--- a/src/cuda/api/multi_wrapper_impls/array.hpp
+++ b/src/cuda/api/multi_wrapper_impls/array.hpp
@@ -34,13 +34,14 @@ array_t<T,NumDimensions> create(
 
 template <typename T, dimensionality_t NumDimensions>
 array_t<T,NumDimensions> create(
-	device_t                     device,
+	const device_t&              device,
 	dimensions_t<NumDimensions>  dimensions)
 {
-	device::current::detail_::scoped_context_override_t set_device_for_this_scope(device.id());
-	auto context_handle =  set_device_for_this_scope.primary_context_handle;
-	handle_t handle = detail_::create<T, NumDimensions>(context_handle, dimensions);
-	return wrap<T, NumDimensions>(device.id(), context_handle, handle, dimensions);
+	auto pc = device.primary_context(do_not_hold_primary_context_refcount_unit);
+	return create<T, NumDimensions>(pc, dimensions);
+		// Note that we have no guarantee that the device's primary context
+		// will continue to exist/be active when returning from this call;
+		// that's the caller's responsibility
 }
 
 } // namespace array

--- a/src/cuda/api/multi_wrapper_impls/context.hpp
+++ b/src/cuda/api/multi_wrapper_impls/context.hpp
@@ -124,25 +124,25 @@ inline handle_t push_default_if_missing()
  */
 class scoped_existence_ensurer_t {
 public:
-	context::handle_t maybe_pc_handle_;
+	context::handle_t context_handle;
 	device::id_t device_id_;
 	bool decrease_pc_refcount_on_destruct_;
 
-	explicit scoped_existence_ensurer_t(bool decrease_pc_refcount_on_destruct = true)
-		: maybe_pc_handle_(get_handle()),
-		  decrease_pc_refcount_on_destruct_(decrease_pc_refcount_on_destruct)
+	explicit scoped_existence_ensurer_t(bool avoid_pc_refcount_increase = true)
+		: context_handle(get_handle()),
+		  decrease_pc_refcount_on_destruct_(avoid_pc_refcount_increase)
 	{
-		if (maybe_pc_handle_ == context::detail_::none) {
+		if (context_handle == context::detail_::none) {
 			device_id_ = device::current::detail_::get_id();
-			maybe_pc_handle_ = device::primary_context::detail_::obtain_and_increase_refcount(device_id_);
-			context::current::detail_::push(maybe_pc_handle_);
+			context_handle = device::primary_context::detail_::obtain_and_increase_refcount(device_id_);
+			context::current::detail_::push(context_handle);
 		}
 		else { decrease_pc_refcount_on_destruct_ = false; }
 	}
 
 	~scoped_existence_ensurer_t()
 	{
-	    if (maybe_pc_handle_ != context::detail_::none and decrease_pc_refcount_on_destruct_) {
+	    if (context_handle != context::detail_::none and decrease_pc_refcount_on_destruct_) {
             context::current::detail_::pop();
 	        device::primary_context::detail_::decrease_refcount(device_id_);
 	    }

--- a/src/cuda/api/multi_wrapper_impls/device.hpp
+++ b/src/cuda/api/multi_wrapper_impls/device.hpp
@@ -45,6 +45,19 @@ inline primary_context_t get(const device_t& device)
 	return detail_::wrap( device.id(), pc_handle, true);
 }
 
+namespace detail_ {
+
+// Use this when you need a PC, you don't have a device_t to hang it on,
+// and you don't want it to get deactivated/destroyed right after you use it.
+inline primary_context_t leaky_get(cuda::device::id_t device_id)
+{
+	bool need_to_activate_and_leak = not cuda::device::primary_context::detail_::is_active(device_id);
+	auto pc_handle = cuda::device::primary_context::detail_::get_handle(device_id, true);
+	return cuda::device::primary_context::detail_::wrap(device_id, pc_handle, not need_to_activate_and_leak);
+}
+
+} // namespace detail_
+
 } // namespace primary_context
 
 namespace peer_to_peer {

--- a/src/cuda/api/multi_wrapper_impls/device.hpp
+++ b/src/cuda/api/multi_wrapper_impls/device.hpp
@@ -111,35 +111,32 @@ inline stream_t primary_context_t::default_stream() const noexcept
 	return stream::wrap(device_id_, handle_, stream::default_stream_handle);
 }
 
-namespace current {
-
-
-inline scoped_override_t::scoped_override_t(const device_t& device) : parent(device.id()) { }
-inline scoped_override_t::scoped_override_t(device_t&& device) : parent(device.id()) { }
-
-} // namespace current
 } // namespace device
 
 // device_t methods
 
-inline stream_t device_t::default_stream() const
+inline stream_t device_t::default_stream(bool hold_primary_context_refcount_unit) const
 {
-	return stream::wrap(id(), primary_context_handle(), stream::default_stream_handle);
+	auto pc = primary_context();
+	if (hold_primary_context_refcount_unit) {
+		device::primary_context::detail_::increase_refcount(id_);
+	}
+	return stream::wrap(
+		id(), pc.handle(), stream::default_stream_handle,
+		do_not_take_ownership, hold_primary_context_refcount_unit);
 }
 
 inline stream_t device_t::create_stream(
 	bool                will_synchronize_with_default_stream,
 	stream::priority_t  priority) const
 {
-	device::current::detail_::scoped_context_override_t set_device_for_this_scope(id_);
-	return stream::detail_::create(id_, primary_context_handle(), will_synchronize_with_default_stream, priority);
+	return stream::create(*this, will_synchronize_with_default_stream, priority);
 }
 
-inline device::primary_context_t device_t::primary_context(bool scoped) const
+inline device::primary_context_t device_t::primary_context(bool hold_pc_refcount_unit) const
 {
 	auto pc_handle = primary_context_handle();
-	auto decrease_refcount_on_destruct = not scoped;
-	if (not scoped) {
+	if (hold_pc_refcount_unit) {
 		device::primary_context::detail_::increase_refcount(id_);
 		// Q: Why increase the refcount here, when `primary_context_handle()`
 		//    ensured this has already happened for this object?
@@ -147,7 +144,7 @@ inline device::primary_context_t device_t::primary_context(bool scoped) const
 		//    unit (e.g. in case this object gets destructed but the
 		//    primary_context_t is still alive.
 	}
-	return device::primary_context::detail_::wrap(id_, pc_handle, decrease_refcount_on_destruct);
+	return device::primary_context::detail_::wrap(id_, pc_handle, hold_pc_refcount_unit);
 }
 
 inline void synchronize(const device_t& device)
@@ -162,21 +159,22 @@ void device_t::launch(
 KernelFunction kernel_function, launch_configuration_t launch_configuration,
 KernelParameters ... parameters) const
 {
-	return default_stream().enqueue.kernel_launch(
+	auto pc = primary_context();
+	pc.default_stream().enqueue.kernel_launch(
 	kernel_function, launch_configuration, parameters...);
 }
 
 inline context_t device_t::create_context(
-context::host_thread_synch_scheduling_policy_t  synch_scheduling_policy,
-bool                                            keep_larger_local_mem_after_resize) const
+	context::host_thread_synch_scheduling_policy_t  synch_scheduling_policy,
+	bool                                            keep_larger_local_mem_after_resize) const
 {
 	return context::create(*this, synch_scheduling_policy, keep_larger_local_mem_after_resize);
 }
 
 inline event_t device_t::create_event(
-bool          uses_blocking_sync,
-bool          records_timing,
-bool          interprocess)
+	bool          uses_blocking_sync,
+	bool          records_timing,
+	bool          interprocess)
 {
 	// The current implementation of event::create is not super-smart,
 	// but it's probably not worth it trying to improve just this function

--- a/src/cuda/api/multi_wrapper_impls/device.hpp
+++ b/src/cuda/api/multi_wrapper_impls/device.hpp
@@ -76,7 +76,7 @@ inline void disable_access(device_t accessor, device_t peer)
 {
 #ifndef NDEBUG
 	if (accessor == peer) {
-		throw std::invalid_argument("A device cannot be used as its own peer");
+		throw ::std::invalid_argument("A device cannot be used as its own peer");
 	}
 #endif
 	context::peer_to_peer::disable_access(accessor.primary_context(), peer.primary_context());
@@ -91,7 +91,7 @@ inline void enable_bidirectional_access(device_t first, device_t second)
 {
 #ifndef NDEBUG
 	if (first == second) {
-		throw std::invalid_argument("A device cannot be used as its own peer");
+		throw ::std::invalid_argument("A device cannot be used as its own peer");
 	}
 #endif
 	context::peer_to_peer::enable_bidirectional_access(first.primary_context(), second.primary_context());
@@ -101,7 +101,7 @@ inline void disable_bidirectional_access(device_t first, device_t second)
 {
 #ifndef NDEBUG
 	if (first == second) {
-		throw std::invalid_argument("A device cannot be used as its own peer");
+		throw ::std::invalid_argument("A device cannot be used as its own peer");
 	}
 #endif
 	context::peer_to_peer::disable_bidirectional_access(first.primary_context(), second.primary_context());
@@ -111,7 +111,7 @@ inline attribute_value_t get_attribute(attribute_t attribute, device_t first, de
 {
 #ifndef NDEBUG
 	if (first == second) {
-		throw std::invalid_argument("A device cannot be used as its own peer");
+		throw ::std::invalid_argument("A device cannot be used as its own peer");
 	}
 #endif
 	return detail_::get_attribute(attribute, first.id(), second.id());
@@ -209,7 +209,7 @@ inline device::primary_context_t get_implicit_primary_context<kernel_t>(kernel_t
 	auto device = context.device();
 	auto primary_context = device.primary_context();
 	if (context != primary_context) {
-		throw std::logic_error("Attempt to launch a kernel associated with a non-primary context without specifying a stream associated with that context.");
+		throw ::std::logic_error("Attempt to launch a kernel associated with a non-primary context without specifying a stream associated with that context.");
 	}
 	return primary_context;
 }

--- a/src/cuda/api/multi_wrapper_impls/event.hpp
+++ b/src/cuda/api/multi_wrapper_impls/event.hpp
@@ -115,7 +115,7 @@ inline void event_t::record(const stream_t& stream) const
 {
 #ifndef NDEBUG
 	if (stream.context_handle() != context_handle_) {
-		throw std::invalid_argument("Attempt to record an event on a stream in a different context");
+		throw ::std::invalid_argument("Attempt to record an event on a stream in a different context");
 	}
 #endif
 	event::detail_::enqueue(context_handle_, stream.handle(), handle_);

--- a/src/cuda/api/multi_wrapper_impls/kernel.hpp
+++ b/src/cuda/api/multi_wrapper_impls/kernel.hpp
@@ -40,10 +40,15 @@ apriori_compiled_kernel_t get(context_t context, KernelFunctionPtr function_ptr)
 	return detail_::wrap(context.device_id(), context.handle(), handle, ptr_);
 }
 
+/**
+ * @note The returned kernel proxy object will keep the device's primary
+ * context active while the kernel exists.
+ */
 template<typename KernelFunctionPtr>
-apriori_compiled_kernel_t get(device_t device, KernelFunctionPtr function_ptr)
+apriori_compiled_kernel_t get(const device_t& device, KernelFunctionPtr function_ptr)
 {
-	return get<KernelFunctionPtr>(device.primary_context(), function_ptr);
+	auto primary_context = device.primary_context(do_hold_primary_context_refcount_unit);
+	return get<KernelFunctionPtr>(primary_context, function_ptr);
 }
 
 } // namespace kernel

--- a/src/cuda/api/multi_wrapper_impls/kernel.hpp
+++ b/src/cuda/api/multi_wrapper_impls/kernel.hpp
@@ -74,7 +74,7 @@ inline void kernel_t::set_attribute(kernel::attribute_t attribute, kernel::attri
 #ifndef NDEBUG
 		::std::string(kernel::detail_::attribute_name(attribute)) +
 #else
-		::std::to_string(static_cast<std::underlying_type<kernel::attribute_t>::type>(attribute)) +
+		::std::to_string(static_cast<::std::underlying_type<kernel::attribute_t>::type>(attribute)) +
 #endif
 		" to value " + ::std::to_string(value)	);
 	throw(cuda::runtime_error {cuda::status::not_yet_implemented});

--- a/src/cuda/api/multi_wrapper_impls/kernel_launch.hpp
+++ b/src/cuda/api/multi_wrapper_impls/kernel_launch.hpp
@@ -46,7 +46,7 @@ void enqueue_launch_helper<apriori_compiled_kernel_t, KernelParameters...>::oper
 }
 
 template<typename... KernelParameters>
-std::array<void*, sizeof...(KernelParameters)>
+::std::array<void*, sizeof...(KernelParameters)>
 marshal_dynamic_kernel_arguments(KernelParameters&&... parameters)
 {
 	return ::std::array<void*, sizeof...(KernelParameters)> { &parameters... };

--- a/src/cuda/api/multi_wrapper_impls/memory.hpp
+++ b/src/cuda/api/multi_wrapper_impls/memory.hpp
@@ -152,8 +152,9 @@ template<typename T>
 inline unique_ptr<T> make_unique(size_t num_elements)
 {
 	static_assert(::std::is_array<T>::value, "make_unique<T>() can only be invoked for T being an array type, T = U[]");
-	auto device = cuda::device::current::get();
-	make_unique<T>(device, num_elements);
+	auto current_device_id = cuda::device::current::detail_::get_id();
+	auto pc = cuda::device::primary_context::detail_::leaky_get(current_device_id);
+	return make_unique<T>(pc, num_elements);
 }
 
 /**
@@ -195,6 +196,9 @@ inline unique_ptr<T> make_unique(const device_t& device)
  * @note The allocation will be made in the device's primary context -
  * which will be created if it has not yet been.
  *
+ * @note If called when the device' primary context is inactive,
+ * this
+ *
  * @tparam T  the type of value to construct in device memory
  *
  * @param num_elements  the number of elements to allocate
@@ -204,8 +208,9 @@ inline unique_ptr<T> make_unique(const device_t& device)
 template<typename T>
 inline unique_ptr<T> make_unique()
 {
-	auto device = cuda::device::current::get();
-	make_unique<T>(device);
+	auto current_device_id = cuda::device::current::detail_::get_id();
+	auto pc = cuda::device::primary_context::detail_::leaky_get(current_device_id);
+	return make_unique<T>(pc);
 }
 
 } // namespace device
@@ -321,8 +326,9 @@ inline unique_ptr<T> make_unique(
 	size_t                n,
 	initial_visibility_t  initial_visibility)
 {
-	auto device = cuda::device::current::get();
-	return make_unique<T>(device, n, initial_visibility);
+	auto current_device_id = cuda::device::current::detail_::get_id();
+	auto pc = cuda::device::primary_context::detail_::leaky_get(current_device_id);
+	return make_unique<T>(pc, n, initial_visibility);
 }
 
 template<typename T>
@@ -348,8 +354,9 @@ template<typename T>
 inline unique_ptr<T> make_unique(
 	initial_visibility_t  initial_visibility)
 {
-	auto device = cuda::device::current::get();
-	return make_unique<T>(initial_visibility);
+	auto current_device_id = cuda::device::current::detail_::get_id();
+	auto pc = cuda::device::primary_context::detail_::leaky_get(current_device_id);
+	return make_unique<T>(pc, initial_visibility);
 }
 
 

--- a/src/cuda/api/multi_wrapper_impls/memory.hpp
+++ b/src/cuda/api/multi_wrapper_impls/memory.hpp
@@ -68,8 +68,8 @@ inline region_t allocate(const context_t& context, size_t size_in_bytes)
 
 inline region_t allocate(const device_t& device, size_t size_in_bytes)
 {
-	cuda::device::current::detail_::scoped_context_override_t set_device_for_this_scope{device.id()};
-	return detail_::allocate_in_current_context(size_in_bytes);
+	auto pc = device.primary_context();
+	return allocate(pc, size_in_bytes);
 }
 
 namespace async {
@@ -127,10 +127,11 @@ inline unique_ptr<T> make_unique(const context_t& context, size_t num_elements)
  * @return an ::std::unique_ptr pointing to the constructed T array
  */
 template<typename T>
-inline unique_ptr<T> make_unique(device_t device, size_t num_elements)
+inline unique_ptr<T> make_unique(const device_t& device, size_t num_elements)
 {
 	static_assert(::std::is_array<T>::value, "make_unique<T>() can only be invoked for T being an array type, T = U[]");
-	cuda::device::current::detail_::scoped_context_override_t set_device_for_this_scope(device.id());
+	auto pc = device.primary_context();
+	context::current::detail_::scoped_override_t set_context_for_this_scope(pc.handle());
 	return memory::detail_::make_unique<T, device::detail_::allocator, device::detail_::deleter>(num_elements);
 }
 
@@ -180,9 +181,10 @@ inline unique_ptr<T> make_unique(const context_t& context)
  * @return an ::std::unique_ptr pointing to the allocated memory
  */
 template <typename T>
-inline unique_ptr<T> make_unique(device_t device)
+inline unique_ptr<T> make_unique(const device_t& device)
 {
-	cuda::device::current::detail_::scoped_context_override_t set_device_for_this_scope(device.id());
+	auto pc = device.primary_context();
+	context::current::detail_::scoped_override_t set_context_for_this_scope(pc.handle());
 	return memory::detail_::make_unique<T, device::detail_::allocator, device::detail_::deleter>();
 }
 
@@ -310,8 +312,8 @@ inline unique_ptr<T> make_unique(
 	size_t                n,
 	initial_visibility_t  initial_visibility)
 {
-	cuda::device::current::detail_::scoped_context_override_t set_device_for_this_scope(device.id());
-	return detail_::make_unique_in_current_context<T>(n, initial_visibility);
+	auto pc = device.primary_context();
+	return make_unique<T>(pc, n, initial_visibility);
 }
 
 template<typename T>
@@ -334,10 +336,11 @@ inline unique_ptr<T> make_unique(
 
 template<typename T>
 inline unique_ptr<T> make_unique(
-	device_t              device,
+	const device_t&       device,
 	initial_visibility_t  initial_visibility)
 {
-	cuda::device::current::detail_::scoped_context_override_t set_device_for_this_scope(device.id());
+	auto pc = device.primary_context();
+	context::current::detail_::scoped_override_t set_context_for_this_scope(pc.handle());
 	return detail_::make_unique_in_current_context<T>(initial_visibility);
 }
 
@@ -410,12 +413,12 @@ inline region_t allocate(
 }
 
 inline region_t allocate(
-	device_t              device,
+	const device_t&       device,
 	size_t                num_bytes,
 	initial_visibility_t  initial_visibility)
 {
-	cuda::device::current::detail_::scoped_context_override_t set_device_for_this_scope{device.id()};
-	return detail_::allocate_in_current_context(num_bytes, initial_visibility);
+	auto pc = device.primary_context();
+	return allocate(pc, num_bytes, initial_visibility);
 }
 
 inline region_t allocate(size_t num_bytes)
@@ -450,17 +453,20 @@ inline region_pair allocate(
 
 namespace host {
 
-// Note: Also increases the reference count to some device context, as otherwise - the
-// allocation may be forgotten later on
+/**
+ * @note The allocation does not keep any device context alive/active; that is
+ * the caller's responsibility. However, if there is no current context, it will
+ * trigger the creation of a primary context on the default device, and "leak"
+ * a refcount unit for it.
+ */
 inline void* allocate(
 	size_t              size_in_bytes,
 	allocation_options  options)
 {
-	constexpr const bool decrease_pc_refcount_on_destruct { false };
+	constexpr const bool dont_decrease_pc_refcount_on_destruct { false };
 	context::current::detail_::scoped_existence_ensurer_t ensure_we_have_a_context{
-		decrease_pc_refcount_on_destruct
+		dont_decrease_pc_refcount_on_destruct
 	};
-	cuda::device::primary_context::detail_::increase_refcount(cuda::device::default_device_id);
 	void* allocated = nullptr;
 	auto flags = memory::detail_::make_cuda_host_alloc_flags(options);
 	auto result = cuMemHostAlloc(&allocated, size_in_bytes, flags);

--- a/src/cuda/api/multi_wrapper_impls/memory.hpp
+++ b/src/cuda/api/multi_wrapper_impls/memory.hpp
@@ -43,7 +43,7 @@ template <typename T, dimensionality_t NumDimensions>
 inline void copy(T* destination, const array_t<T, NumDimensions>& source, const stream_t& stream)
 {
 	if (stream.context_handle() != source.context_handle()) {
-		throw std::invalid_argument("Attempt to copy an array in"
+		throw ::std::invalid_argument("Attempt to copy an array in"
 									+ context::detail_::identify(source.context_handle()) + " via "
 									+ stream::detail_::identify(stream));
 	}
@@ -592,7 +592,7 @@ inline void set_access_mode(
 	access_mode_t                access_mode)
 {
 	auto descriptors = new CUmemAccessDesc[devices.size()];
-	for(std::size_t i = 0; i < devices.size(); i++) {
+	for(::std::size_t i = 0; i < devices.size(); i++) {
 		descriptors[i] = {{CU_MEM_LOCATION_TYPE_DEVICE, devices[i].id()}, CUmemAccess_flags(access_mode)};
 	}
 	auto result = cuMemSetAccess(

--- a/src/cuda/api/stream.hpp
+++ b/src/cuda/api/stream.hpp
@@ -824,7 +824,7 @@ public: // constructors and destructor
 		if (holds_pc_refcount_unit) {
 #ifdef NDEBUG
 			device::primary_context::detail_::decrease_refcount_nothrow(device_id_);
-				// Note: "Swallowing" any potential error to avoid std::terminate(); also,
+				// Note: "Swallowing" any potential error to avoid ::std::terminate(); also,
 				// because a failure probably means the primary context is inactive already
 #else
 			device::primary_context::detail_::decrease_refcount(device_id_);

--- a/src/cuda/api/stream.hpp
+++ b/src/cuda/api/stream.hpp
@@ -823,7 +823,7 @@ public: // constructors and destructor
 		// TODO: DRY
 		if (holds_pc_refcount_unit) {
 #ifdef NDEBUG
-			cuDevicePrimaryCtxRelease(device_id_);
+			device::primary_context::detail_::decrease_refcount_nothrow(device_id_);
 				// Note: "Swallowing" any potential error to avoid std::terminate(); also,
 				// because a failure probably means the primary context is inactive already
 #else

--- a/src/cuda/api/types.hpp
+++ b/src/cuda/api/types.hpp
@@ -20,7 +20,7 @@
 #define CUDA_API_WRAPPERS_COMMON_TYPES_HPP_
 
 #if (__cplusplus < 201103L && (!defined(_MSVC_LANG) || _MSVC_LANG < 201103L))
-#error "The CUDA Runtime API headers can only be compiled with C++11 or a later version of the C++ language standard"
+#error "The CUDA API headers can only be compiled with C++11 or a later version of the C++ language standard"
 #endif
 
 #ifndef __CUDACC__

--- a/src/cuda/api/types.hpp
+++ b/src/cuda/api/types.hpp
@@ -68,38 +68,38 @@ namespace cuda {
 
 namespace detail_ {
 
-// This is available in C++17 as std::void_t, but we're only assuming C++11
+// This is available in C++17 as ::std::void_t, but we're only assuming C++11
 template<typename... Ts>
 using void_t = void;
 
 // This is available in C++14
 template<bool B, typename T>
-using enable_if_t = typename std::enable_if<B, T>::type;
+using enable_if_t = typename ::std::enable_if<B, T>::type;
 
 template<typename T>
-using remove_reference_t = typename std::remove_reference<T>::type;
+using remove_reference_t = typename ::std::remove_reference<T>::type;
 
 // primary template handles types that have no nested ::type member:
 template <typename, typename = void>
-struct has_data_method : std::false_type { };
+struct has_data_method : ::std::false_type { };
 
 // specialization recognizes types that do have a nested ::type member:
 template <typename T>
-struct has_data_method<T, cuda::detail_::void_t<decltype(std::declval<T>().data())>> : std::true_type { };
+struct has_data_method<T, cuda::detail_::void_t<decltype(::std::declval<T>().data())>> : ::std::true_type { };
 
 template <typename, typename = void>
-struct has_value_type_member : std::false_type { };
+struct has_value_type_member : ::std::false_type { };
 
 template <typename T>
-struct has_value_type_member<T, cuda::detail_::void_t<typename T::value_type>> : std::true_type { };
+struct has_value_type_member<T, cuda::detail_::void_t<typename T::value_type>> : ::std::true_type { };
 
 // TODO: Consider either beefing up this type trait or ditching it in favor of something simpler, or
 // in the standard library
 template <typename T>
 struct is_kinda_like_contiguous_container :
-	std::integral_constant<bool,
-		has_data_method<typename std::remove_reference<T>::type>::value
-			and has_value_type_member<typename std::remove_reference<T>::type>::value
+	::std::integral_constant<bool,
+		has_data_method<typename ::std::remove_reference<T>::type>::value
+			and has_value_type_member<typename ::std::remove_reference<T>::type>::value
 	> {};
 
 } // namespace detail_
@@ -539,7 +539,7 @@ private:
 	T* start_ = nullptr;
 	size_t size_in_bytes_ = 0;
 
-	using char_type = typename std::conditional<std::is_const<T>::value, const char *, char *>::type;
+	using char_type = typename ::std::conditional<::std::is_const<T>::value, const char *, char *>::type;
 public:
 	base_region_t() = default;
 	base_region_t(T* start, size_t size_in_bytes)
@@ -568,10 +568,10 @@ protected:
 	{
 #ifndef NDEBUG
 		if (offset_in_bytes >= size_in_bytes_) {
-			throw std::invalid_argument("subregion begins past region end");
+			throw ::std::invalid_argument("subregion begins past region end");
 		}
 		else if (offset_in_bytes + size_in_bytes > size_in_bytes_) {
-			throw std::invalid_argument("subregion exceeds original region bounds");
+			throw ::std::invalid_argument("subregion exceeds original region bounds");
 		}
 #endif
 		return { static_cast<char_type>(start_) + offset_in_bytes, size_in_bytes };

--- a/src/cuda/api/unique_ptr.hpp
+++ b/src/cuda/api/unique_ptr.hpp
@@ -4,6 +4,9 @@
  * @brief A smart pointer for CUDA device- and host-side memory, similar
  * to the standard library's <a href="http://en.cppreference.com/w/cpp/memory/unique_ptr">::std::unique_ptr</a>.
  *
+ * @note Unique pointers, like any (wrapped) memory allocations, do _not_ extend the lifetime of
+ * contexts (primary or otherwise). In particular, they do not increase primary context refcounts.
+ *
  */
 #ifndef CUDA_API_WRAPPERS_UNIQUE_PTR_HPP_
 #define CUDA_API_WRAPPERS_UNIQUE_PTR_HPP_
@@ -100,7 +103,7 @@ template<typename T>
 inline unique_ptr<T> make_unique(const context_t& context, size_t n);
 
 template<typename T>
-inline unique_ptr<T> make_unique(device_t device, size_t n);
+inline unique_ptr<T> make_unique(const device_t& device, size_t n);
 
 template<typename T>
 inline unique_ptr<T> make_unique(size_t n);
@@ -109,7 +112,7 @@ template<typename T>
 inline unique_ptr<T> make_unique(const context_t& context);
 
 template<typename T>
-inline unique_ptr<T> make_unique(device_t device);
+inline unique_ptr<T> make_unique(const device_t& device);
 
 template<typename T>
 inline unique_ptr<T> make_unique();

--- a/src/cuda/api/virtual_memory.hpp
+++ b/src/cuda/api/virtual_memory.hpp
@@ -120,7 +120,7 @@ template<kind_t SharedHandleKind> struct shared_handle_type_helper;
 
 template <> struct shared_handle_type_helper<kind_t::posix_file_descriptor> { using type = int; };
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-template <> struct shared_handle_type_helper<kind_t::win32_handle> { using type = HANDLE; };
+template <> struct shared_handle_type_helper<kind_t::win32_handle> { using type = void *; };
 #endif
 // TODO: What about WIN32_KMT?
 } // namespace detail_

--- a/src/cuda/api/virtual_memory.hpp
+++ b/src/cuda/api/virtual_memory.hpp
@@ -91,7 +91,7 @@ inline reserved_address_range_t reserve(region_t requested_region, alignment_t a
     CUdeviceptr ptr;
     auto status = cuMemAddressReserve(&ptr, requested_region.size(), alignment, requested_region.device_address(), flags);
     throw_if_error(status, "Failed making a reservation of " + cuda::memory::detail_::identify(requested_region)
-		+ " with alignment value " + std::to_string(alignment));
+		+ " with alignment value " + ::std::to_string(alignment));
     bool is_owning { true };
     return detail_::wrap(memory::region_t { ptr, requested_region.size() }, alignment, is_owning);
 }
@@ -269,8 +269,8 @@ physical_allocation_t create(size_t size, device_t device);
 namespace detail_ {
 
 inline ::std::string identify(handle_t handle, size_t size) {
-	return ::std::string("physical allocation with handle ") + std::to_string(handle)
-		+ " of size " + std::to_string(size);
+	return ::std::string("physical allocation with handle ") + ::std::to_string(handle)
+		+ " of size " + ::std::to_string(size);
 }
 
 inline physical_allocation_t wrap(handle_t handle, size_t size, bool holds_refcount_unit)

--- a/src/cuda/nvrtc.hpp
+++ b/src/cuda/nvrtc.hpp
@@ -9,7 +9,9 @@
 #ifndef CUDA_NVRTC_WRAPPERS_HPP_
 #define CUDA_NVRTC_WRAPPERS_HPP_
 
-static_assert(__cplusplus >= 201103L, "The CUDA NVTX API wrappers can only be compiled with C++11 or a later version of the C++ language standard");
+#if (__cplusplus < 201103L && (!defined(_MSVC_LANG) || _MSVC_LANG < 201103L))
+#error "The CUDA API headers can only be compiled with C++11 or a later version of the C++ language standard"
+#endif
 
 #include <cuda/nvrtc/error.hpp>
 #include <cuda/nvrtc/compilation_options.hpp>

--- a/src/cuda/nvrtc/compilation_options.hpp
+++ b/src/cuda/nvrtc/compilation_options.hpp
@@ -101,7 +101,7 @@ cpp_dialect_t cpp_dialect_from_name(const char* dialect_name) noexcept(false)
 			return static_cast<cpp_dialect_t>(known_dialect);
 		}
 	}
-	throw std::invalid_argument(std::string("No C++ dialect named \"") + dialect_name + '"');
+	throw ::std::invalid_argument(::std::string("No C++ dialect named \"") + dialect_name + '"');
 }
 
 } // namespace detail_
@@ -122,7 +122,7 @@ struct compilation_options_t {
 	 *
 	 * @note As of CUDA 11.0, the default is compute_52.
 	 *
-	 * @todo Use something less fancy than std::unordered_set, e.g.
+	 * @todo Use something less fancy than ::std::unordered_set, e.g.
 	 * a vector-backed ordered set or a dynamic bit-vector for membership.
 	 */
     ::std::unordered_set<cuda::device::compute_capability_t> targets_;
@@ -238,7 +238,7 @@ struct compilation_options_t {
 
     ::std::unordered_set<::std::string> no_value_defines;
 
-    ::std::unordered_map<::std::string,std::string> valued_defines;
+    ::std::unordered_map<::std::string,::std::string> valued_defines;
 
     bool disable_warnings { false };
 

--- a/src/cuda/nvrtc/detail/marshalled_options.hpp
+++ b/src/cuda/nvrtc/detail/marshalled_options.hpp
@@ -8,7 +8,7 @@
 #include <vector>
 #include <string>
 #include <cstring>
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 #include <charconv>
 #endif
 
@@ -42,7 +42,7 @@ public:
 	void append_to_current(long v)
 	{
 		char v_buffer[::std::numeric_limits<long>::digits10 + 2];
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 		auto result = ::std::to_chars(v_buffer, v_buffer + sizeof(v_buffer), v);
 		auto num_chars = result.ptr - v_buffer;
 #else
@@ -57,9 +57,24 @@ public:
 	void append_to_current(unsigned long v)
 	{
 		char v_buffer[::std::numeric_limits<unsigned long>::digits10 + 2];
-#if __cplusplus >= 201703L
-		auto result = ::std::to_chars(int_buffer, int_buffer + sizeof(int_buffer), v);
-		auto num_chars = result.ptr - int_buffer;
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+		auto result = ::std::to_chars(v_buffer, v_buffer + sizeof(v_buffer), v);
+		auto num_chars = result.ptr - v_buffer;
+#else
+		auto num_chars = snprintf(v_buffer, sizeof(v_buffer), "%lu", v);
+		// Q: Why can't we just print directly into the buffer?
+		// A: There is no buffer, this is the size computer.
+
+#endif
+		buffer_pos_ += num_chars;
+	}
+
+	void append_to_current(unsigned long long v)
+	{
+		char v_buffer[::std::numeric_limits<unsigned long long>::digits10 + 2];
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+		auto result = ::std::to_chars(v_buffer, v_buffer + sizeof(v_buffer), v);
+		auto num_chars = result.ptr - v_buffer;
 #else
 		auto num_chars = snprintf(v_buffer, sizeof(v_buffer), "%lu", v);
 		// Q: Why can't we just print directly into the buffer?
@@ -72,7 +87,7 @@ public:
 	void append_to_current(int v)
 	{
 		char v_buffer[::std::numeric_limits<int>::digits10 + 2];
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 		auto result = ::std::to_chars(v_buffer, v_buffer + sizeof(v_buffer), v);
 		auto num_chars = result.ptr - v_buffer;
 #else
@@ -87,9 +102,9 @@ public:
 	void append_to_current(unsigned v)
 	{
 		char v_buffer[::std::numeric_limits<unsigned>::digits10 + 2];
-#if __cplusplus >= 201703L
-		auto result = ::std::to_chars(int_buffer, int_buffer + sizeof(int_buffer), v);
-		auto num_chars = result.ptr - int_buffer;
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+		auto result = ::std::to_chars(v_buffer, v_buffer + sizeof(v_buffer), v);
+		auto num_chars = result.ptr - v_buffer;
 #else
 		auto num_chars = snprintf(v_buffer, sizeof(v_buffer), "%u", v);
 		// Q: Why can't we just print directly into the buffer?
@@ -191,7 +206,7 @@ public:
 		}
 #endif
 		constexpr const ::std::size_t v_size = ::std::numeric_limits<long>::digits10;
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 		auto result = ::std::to_chars(current_pos(), current_pos() + v_size, v);
 		auto num_chars = result.ptr - current_pos();
 #else
@@ -208,7 +223,24 @@ public:
 		}
 #endif
 		constexpr const ::std::size_t v_size = ::std::numeric_limits<unsigned long>::digits10;
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
+		auto result = ::std::to_chars(current_pos(), current_pos() + v_size, v);
+		auto num_chars = result.ptr - current_pos();
+#else
+		auto num_chars = snprintf(current_pos(), v_size, "%lu", v);
+#endif
+		buffer_pos_ += num_chars;
+	}
+
+	void append_to_current(unsigned long long v)
+	{
+#ifndef NDEBUG
+		if (num_options_ >= option_ptrs_.size()) {
+			::std::runtime_error("Attempt to prepare an option beyond the maximum number of options");
+		}
+#endif
+		constexpr const ::std::size_t v_size = ::std::numeric_limits<unsigned long>::digits10;
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 		auto result = ::std::to_chars(current_pos(), current_pos() + v_size, v);
 		auto num_chars = result.ptr - current_pos();
 #else
@@ -225,7 +257,7 @@ public:
 		}
 #endif
 		constexpr const ::std::size_t v_size = ::std::numeric_limits<int>::digits10;
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 		auto result = ::std::to_chars(current_pos(), current_pos() + v_size, v);
 		auto num_chars = result.ptr - current_pos();
 #else
@@ -242,7 +274,7 @@ public:
 		}
 #endif
 		constexpr const ::std::size_t v_size = ::std::numeric_limits<unsigned>::digits10;
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 		auto result = ::std::to_chars(current_pos(), current_pos() + v_size, v);
 		auto num_chars = result.ptr - current_pos();
 #else

--- a/src/cuda/nvrtc/detail/marshalled_options.hpp
+++ b/src/cuda/nvrtc/detail/marshalled_options.hpp
@@ -170,8 +170,8 @@ public:
 		}
 		auto remaining = buffer_.size() - buffer_pos_; // including space for a last '\0'
 		if (sv.size() + 1 > remaining) {
-			throw std::logic_error("Not enough buffer space left for C-string argument: "
-				+ std::to_string(sv.size() + 1) + " > " + std::to_string(remaining));
+			throw ::std::logic_error("Not enough buffer space left for C-string argument: "
+				+ ::std::to_string(sv.size() + 1) + " > " + ::std::to_string(remaining));
 		}
 #endif
 		::std::copy_n(sv.cbegin(), sv.size(), current_pos());

--- a/src/cuda/nvrtc/detail/marshalled_options.hpp
+++ b/src/cuda/nvrtc/detail/marshalled_options.hpp
@@ -39,14 +39,44 @@ public:
 		append_to_current(string_view{str, ::std::strlen(str)});
 	}
 
-	void append_to_current(::std::size_t v)
+	void append_to_current(long v)
 	{
-		char size_t_buffer[::std::numeric_limits<::std::size_t>::digits10 + 2];
+		char v_buffer[::std::numeric_limits<long>::digits10 + 2];
 #if __cplusplus >= 201703L
-		auto result = ::std::to_chars(size_t_buffer, size_t_buffer + sizeof(size_t_buffer), v);
-		auto num_chars = result.ptr - size_t_buffer;
+		auto result = ::std::to_chars(v_buffer, v_buffer + sizeof(v_buffer), v);
+		auto num_chars = result.ptr - v_buffer;
 #else
-		auto num_chars = snprintf(size_t_buffer, sizeof(size_t_buffer), "%zu", v);
+		auto num_chars = snprintf(v_buffer, sizeof(long), "%ld", v);
+		// Q: Why can't we just print directly into the buffer?
+		// A: There is no buffer, this is the size computer.
+
+#endif
+		buffer_pos_ += num_chars;
+	}
+
+	void append_to_current(unsigned long v)
+	{
+		char v_buffer[::std::numeric_limits<unsigned long>::digits10 + 2];
+#if __cplusplus >= 201703L
+		auto result = ::std::to_chars(int_buffer, int_buffer + sizeof(int_buffer), v);
+		auto num_chars = result.ptr - int_buffer;
+#else
+		auto num_chars = snprintf(v_buffer, sizeof(v_buffer), "%lu", v);
+		// Q: Why can't we just print directly into the buffer?
+		// A: There is no buffer, this is the size computer.
+
+#endif
+		buffer_pos_ += num_chars;
+	}
+
+	void append_to_current(int v)
+	{
+		char v_buffer[::std::numeric_limits<int>::digits10 + 2];
+#if __cplusplus >= 201703L
+		auto result = ::std::to_chars(v_buffer, v_buffer + sizeof(v_buffer), v);
+		auto num_chars = result.ptr - v_buffer;
+#else
+		auto num_chars = snprintf(v_buffer, sizeof(int), "%d", v);
 		// Q: Why can't we just print directly into the buffer?
 		// A: There is no buffer, this is the size computer.
 
@@ -56,14 +86,14 @@ public:
 
 	void append_to_current(unsigned v)
 	{
-		char int_buffer[::std::numeric_limits<unsigned>::digits10 + 2];
+		char v_buffer[::std::numeric_limits<unsigned>::digits10 + 2];
 #if __cplusplus >= 201703L
 		auto result = ::std::to_chars(int_buffer, int_buffer + sizeof(int_buffer), v);
 		auto num_chars = result.ptr - int_buffer;
 #else
-		auto num_chars = snprintf(int_buffer, sizeof(int_buffer), "%u", v);
-			// Q: Why can't we just print directly into the buffer?
-			// A: There is no buffer, this is the size computer.
+		auto num_chars = snprintf(v_buffer, sizeof(v_buffer), "%u", v);
+		// Q: Why can't we just print directly into the buffer?
+		// A: There is no buffer, this is the size computer.
 
 #endif
 		buffer_pos_ += num_chars;
@@ -73,20 +103,6 @@ public:
 	{
 		buffer_pos_++;
 	}
-
-
-//	void append_to_current(I v)
-//	{
-//		using decayed = typename ::std::decay<I>::type;
-//		char int_buffer[::std::numeric_limits<decayed>::digits10 + 2];
-//#if __cplusplus >= 201703L
-//		auto result = ::std::to_chars(buffer, buffer + sizeof(buffer), v);
-//		auto num_chars = result.ptr - int_buffer;
-//#else
-//		auto num_chars = snprintf(int_buffer, sizeof(int_buffer), "%lld", (long long) v);
-//#endif
-//		buffer_pos_ += num_chars;
-//	}
 
 	void finalize_current()
 	{
@@ -167,19 +183,53 @@ public:
 		append_to_current(string_view{str, ::std::strlen(str)});
 	}
 
-	void append_to_current(::std::size_t v)
+	void append_to_current(long v)
 	{
 #ifndef NDEBUG
 		if (num_options_ >= option_ptrs_.size()) {
 			::std::runtime_error("Attempt to prepare an option beyond the maximum number of options");
 		}
 #endif
-		constexpr const ::std::size_t uint_size = ::std::numeric_limits<::std::size_t>::digits10;
+		constexpr const ::std::size_t v_size = ::std::numeric_limits<long>::digits10;
 #if __cplusplus >= 201703L
-		auto result = ::std::to_chars(current_pos(), current_pos() + uint_size, v);
+		auto result = ::std::to_chars(current_pos(), current_pos() + v_size, v);
 		auto num_chars = result.ptr - current_pos();
 #else
-		auto num_chars = snprintf(current_pos(), uint_size, "%zu", v);
+		auto num_chars = snprintf(current_pos(), v_size, "%ld", v);
+#endif
+		buffer_pos_ += num_chars;
+	}
+
+	void append_to_current(unsigned long v)
+	{
+#ifndef NDEBUG
+		if (num_options_ >= option_ptrs_.size()) {
+			::std::runtime_error("Attempt to prepare an option beyond the maximum number of options");
+		}
+#endif
+		constexpr const ::std::size_t v_size = ::std::numeric_limits<unsigned long>::digits10;
+#if __cplusplus >= 201703L
+		auto result = ::std::to_chars(current_pos(), current_pos() + v_size, v);
+		auto num_chars = result.ptr - current_pos();
+#else
+		auto num_chars = snprintf(current_pos(), v_size, "%lu", v);
+#endif
+		buffer_pos_ += num_chars;
+	}
+
+	void append_to_current(int v)
+	{
+#ifndef NDEBUG
+		if (num_options_ >= option_ptrs_.size()) {
+			::std::runtime_error("Attempt to prepare an option beyond the maximum number of options");
+		}
+#endif
+		constexpr const ::std::size_t v_size = ::std::numeric_limits<int>::digits10;
+#if __cplusplus >= 201703L
+		auto result = ::std::to_chars(current_pos(), current_pos() + v_size, v);
+		auto num_chars = result.ptr - current_pos();
+#else
+		auto num_chars = snprintf(current_pos(), v_size, "%d", v);
 #endif
 		buffer_pos_ += num_chars;
 	}
@@ -191,12 +241,12 @@ public:
 			::std::runtime_error("Attempt to prepare an option beyond the maximum number of options");
 		}
 #endif
-		constexpr const ::std::size_t uint_size = ::std::numeric_limits<unsigned>::digits10;
+		constexpr const ::std::size_t v_size = ::std::numeric_limits<unsigned>::digits10;
 #if __cplusplus >= 201703L
-		auto result = ::std::to_chars(current_pos(), current_pos() + uint_size, v);
+		auto result = ::std::to_chars(current_pos(), current_pos() + v_size, v);
 		auto num_chars = result.ptr - current_pos();
 #else
-		auto num_chars = snprintf(current_pos(), uint_size, "%u", v);
+		auto num_chars = snprintf(current_pos(), v_size, "%u", v);
 #endif
 		buffer_pos_ += num_chars;
 	}

--- a/src/cuda/nvrtc/name_caching_program.hpp
+++ b/src/cuda/nvrtc/name_caching_program.hpp
@@ -19,7 +19,7 @@ namespace detail_ {
 template<typename C>
 typename C::iterator insert_in_order(C& sorted_container, typename C::value_type&& item )
 {
-	auto pos = std::upper_bound( std::begin(sorted_container), std::end(sorted_container), item);
+	auto pos = ::std::upper_bound( ::std::begin(sorted_container), ::std::end(sorted_container), item);
 	return sorted_container.insert(pos, item);
 }
 
@@ -42,10 +42,10 @@ public: // non-mutators
 
 	const char* get_mangled_registered_name(const char* unmangled_name) const
 	{
-		auto comparator = [](const char* lhs, const char* rhs) { return std::strcmp(lhs, rhs) == 0};
-		auto search_result = std::lower_bound(names_.cbegin(), names_.cend(), unmangled_name);
+		auto comparator = [](const char* lhs, const char* rhs) { return ::std::strcmp(lhs, rhs) == 0};
+		auto search_result = ::std::lower_bound(names_.cbegin(), names_.cend(), unmangled_name);
 		if (search_result == names_.cend() {
-			throw std::invalid_argument("Unmangled name " + unmangled_name + " was not registered for program " + name_);
+			throw ::std::invalid_argument("Unmangled name " + unmangled_name + " was not registered for program " + name_);
 		}
 		auto& mangled = mangled_names[search_result - names_.cbegin()];
 		if (mangled == nullptr) {
@@ -95,8 +95,8 @@ protected: // data members
 
 	// These two are kept sorted
 	// TODO: Use a single vector of pairs?
-	std::vector<const char*> names_ {};
-	std::vector<const char*> mangled_names {};
+	::std::vector<const char*> names_ {};
+	::std::vector<const char*> mangled_names {};
 
 }; // class program_t
 

--- a/src/cuda/nvrtc/program.hpp
+++ b/src/cuda/nvrtc/program.hpp
@@ -152,7 +152,7 @@ public: // non-mutators
 		throw_if_error(status, "Failed determining whether the NVRTC program has a compiled PTX result: " +
 			cuda::rtc::program::detail_::identify(*this));
 		if (size == 0) {
-			throw std::logic_error("PTX size reported as 0 by NVRTC for program: " +
+			throw ::std::logic_error("PTX size reported as 0 by NVRTC for program: " +
 				cuda::rtc::program::detail_::identify(*this));
 		}
 		return true;
@@ -173,7 +173,7 @@ public: // non-mutators
 		auto status = nvrtcGetCUBINSize(handle_, &size);
 		throw_if_error(status, "Failed obtaining NVRTC program output CUBIN size");
 		if (size == 0) {
-			throw std::invalid_argument("CUBIN requested for a CUDA program compiled for a virtual architecture: " +
+			throw ::std::invalid_argument("CUBIN requested for a CUDA program compiled for a virtual architecture: " +
 				cuda::rtc::program::detail_::identify(*this));
 		}
 		dynarray<char> result(size);
@@ -218,7 +218,7 @@ public: // non-mutators
 		throw_if_error(status, "Failed determining whether the NVRTC program has a compiled NVVM result: " +
 			cuda::rtc::program::detail_::identify(*this));
 		if (size == 0) {
-			throw std::logic_error("NVVM size reported as 0 by NVRTC for program: " +
+			throw ::std::logic_error("NVVM size reported as 0 by NVRTC for program: " +
 				cuda::rtc::program::detail_::identify(*this));
 		}
 		return true;
@@ -244,7 +244,7 @@ public: // non-mutators
 		return result;
 	}
 
-	const char* get_mangling_of(const std::string& unmangled_name) const
+	const char* get_mangling_of(const ::std::string& unmangled_name) const
 	{
 		return get_mangling_of(unmangled_name.c_str());
 	}
@@ -299,7 +299,7 @@ public: // mutators of the program, but not of this wrapper class
 		throw_if_error(status, "Failed registering a mangled name with program \"" + name_ + "\"");
 	}
 
-	void register_global(const std::string& unmanged_name)
+	void register_global(const ::std::string& unmanged_name)
 	{
 		register_global(unmanged_name.c_str());
 	}
@@ -310,7 +310,7 @@ public: // mutators of the program, but not of this wrapper class
 		register_global(first);
 		register_global(second);
 		cuda::detail_::for_each_argument(
-			[this](std::string global_name) { register_global(global_name); },
+			[this](::std::string global_name) { register_global(global_name); },
 			more_globals...);
 	}
 
@@ -340,8 +340,8 @@ public: // constructors and destructor
 	{
 		status_t status;
 #ifndef NDEBUG
-		if (num_headers > std::numeric_limits<int>::max()) {
-			throw std::invalid_argument("Cannot process more than " + std::to_string(std::numeric_limits<int>::max()) + " headers.");
+		if (num_headers > ::std::numeric_limits<int>::max()) {
+			throw ::std::invalid_argument("Cannot process more than " + ::std::to_string(::std::numeric_limits<int>::max()) + " headers.");
 		}
 #endif
 		status = nvrtcCreateProgram(&handle_, cuda_source, program_name, (int) num_headers, header_sources, header_names);
@@ -351,7 +351,7 @@ public: // constructors and destructor
 	program_t(const program_t&) = delete;
 
 	program_t(program_t&& other) noexcept
-		: handle_(other.handle_), name_(std::move(other.name_)), owning_(other.owning_)
+		: handle_(other.handle_), name_(::std::move(other.name_)), owning_(other.owning_)
 	{
 		other.owning_ = false;
 	};

--- a/src/cuda/nvrtc/types.hpp
+++ b/src/cuda/nvrtc/types.hpp
@@ -27,7 +27,7 @@ using string_view = bpstd::string_view;
 
 namespace cuda {
 
-// The C++ standard library doesn't offer std::dynarray (although it almost did),
+// The C++ standard library doesn't offer ::std::dynarray (although it almost did),
 // and we won't introduce our own here. So...
 template <typename T>
 using dynarray = ::std::vector<T>;

--- a/src/cuda/nvrtc/types.hpp
+++ b/src/cuda/nvrtc/types.hpp
@@ -11,7 +11,7 @@
 
 #include <vector>
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || _MSVC_LANG >= 201703L
 // #include <filesystem>
 #include <string_view>
 namespace cuda {

--- a/src/cuda/nvtx.hpp
+++ b/src/cuda/nvtx.hpp
@@ -8,7 +8,9 @@
 #ifndef CUDA_NVTX_WRAPPERS_HPP_
 #define CUDA_NVTX_WRAPPERS_HPP_
 
-static_assert(__cplusplus >= 201103L, "The CUDA NVTX API wrappers can only be compiled with C++11 or a later version of the C++ language standard");
+#if (__cplusplus < 201103L && (!defined(_MSVC_LANG) || _MSVC_LANG < 201103L))
+#error "The CUDA API headers can only be compiled with C++11 or a later version of the C++ language standard"
+#endif
 
 #include <cuda/nvtx/profiling.hpp>
 

--- a/src/cuda/nvtx/profiling.hpp
+++ b/src/cuda/nvtx/profiling.hpp
@@ -27,6 +27,10 @@
 #include <nvToolsExtCuda.h>
 #endif
 
+#ifdef _WIN32
+#include <processthreadsapi.h> // for GetThreadId()
+#endif
+
 #ifdef CUDA_API_WRAPPERS_USE_PTHREADS
 #include <pthread.h>
 #else
@@ -335,8 +339,14 @@ void name_device<wchar_t>(device::id_t device_id, const wchar_t* name)
 
 void name(std::thread::id host_thread_id, const char* name)
 {
-	auto handle = *(reinterpret_cast<const std::thread::native_handle_type*>(&host_thread_id));
-	name_host_thread(handle, name);
+	auto native_handle = *(reinterpret_cast<const std::thread::native_handle_type*>(&host_thread_id));
+	uint32_t thread_id =
+#if _WIN32
+		GetThreadId(native_handle);
+#else
+		native_handle;
+#endif
+	name_host_thread(thread_id, name);
 }
 
 } // namespace detail_

--- a/src/cuda/nvtx/profiling.hpp
+++ b/src/cuda/nvtx/profiling.hpp
@@ -337,9 +337,9 @@ void name_device<wchar_t>(device::id_t device_id, const wchar_t* name)
 	nvtxNameCuDeviceW(device_id, name);
 }
 
-void name(std::thread::id host_thread_id, const char* name)
+void name(::std::thread::id host_thread_id, const char* name)
 {
-	auto native_handle = *(reinterpret_cast<const std::thread::native_handle_type*>(&host_thread_id));
+	auto native_handle = *(reinterpret_cast<const ::std::thread::native_handle_type*>(&host_thread_id));
 	uint32_t thread_id =
 #if _WIN32
 		GetThreadId(native_handle);
@@ -362,12 +362,12 @@ void name(std::thread::id host_thread_id, const char* name)
  */
 ///@{
 template <typename CharT>
-void name(const std::thread& host_thread, const CharT* name);
+void name(const ::std::thread& host_thread, const CharT* name);
 
 template <typename CharT>
 void name_this_thread(const CharT* name)
 {
-	detail_::name(std::this_thread::get_id(), name);
+	detail_::name(::std::this_thread::get_id(), name);
 }
 ///@}
 


### PR DESCRIPTION
@symqminh writes:

> The C++ standard checking macros specific to MSVC must also be added
> wherever any C++17 specific feature is used, for example
> std::string_view and std::to_char.
> 
> Additionally, std::size_t evaluates to unsigned long long on some
> platforms, such that overloads in marshalled_options.hpp must support
> unsigned long long.