### PR TITLE
Made some changes to error handling, fixed a compilation error and sanitized macros.

### DIFF
--- a/src/cuda/api/current_context.hpp
+++ b/src/cuda/api/current_context.hpp
@@ -196,7 +196,7 @@ public:
  * prefer @ref SET_CUDA_CONTEXT_FOR_THIS_SCOPE instead.
  */
 #define CAW_SET_SCOPE_CONTEXT(context_handle_expr_) \
-const cuda::context::current::detail_::scoped_override_t caw_context_for_this_scope_(context_handle_expr_)
+const ::cuda::context::current::detail_::scoped_override_t caw_context_for_this_scope_(context_handle_expr_)
 ///@endcond
 
 /**

--- a/src/cuda/api/error.hpp
+++ b/src/cuda/api/error.hpp
@@ -218,7 +218,9 @@ inline ::std::string describe(status_t status)
 {
 	const char* description;
 	auto description_lookup_status = cuGetErrorString(status, &description);
-	return (description_lookup_status != CUDA_SUCCESS) ? nullptr : description;
+	return (description_lookup_status != CUDA_SUCCESS) ? 
+		cudaGetErrorString(static_cast<cudaError_t>(status)) :
+		description;
 }
 inline ::std::string describe(cudaError_t status) { return cudaGetErrorString(status); }
 ///@}
@@ -312,9 +314,9 @@ private:
 
 #define throw_if_error_lazy(status__, ... ) \
 do { \
-	const status_t tie_status__ = static_cast<status_t>(status__); \
-	if (is_failure(tie_status__)) { \
-		throw runtime_error(tie_status__, (__VA_ARGS__)); \
+	const ::cuda::status_t tie_status__ = static_cast<::cuda::status_t>(status__); \
+	if (::cuda::is_failure(tie_status__)) { \
+		throw ::cuda::runtime_error(tie_status__, (__VA_ARGS__)); \
 	} \
 } while(false)
 

--- a/src/cuda/api/kernel_launch.hpp
+++ b/src/cuda/api/kernel_launch.hpp
@@ -162,6 +162,7 @@ void enqueue_raw_kernel_launch_in_current_context(
 			stream_handle
 		>>>(::std::forward<KernelParameters>(parameters)...);
 		cuda::outstanding_error::ensure_none("Kernel launch failed");
+		throw_if_error_lazy(cudaGetLastError(), "Kernel launch failed");
 	}
 	else {
 #if CUDA_VERSION < 9000

--- a/src/cuda/rtc/compilation_options.hpp
+++ b/src/cuda/rtc/compilation_options.hpp
@@ -485,8 +485,8 @@ struct opt_start_t {
 
 } // namespace detail_
 
-template <typename MarshalTarget, typename Delimiter>
-MarshalTarget& operator<<(MarshalTarget& mt, detail_::opt_start_t<Delimiter>& opt_start)
+template <typename Delimiter>
+std::ostream& operator<<(std::ostream& mt, detail_::opt_start_t<Delimiter>& opt_start)
 {
 	if (not opt_start.ever_used) {
 		opt_start.ever_used = true;

--- a/src/cuda/rtc/error.hpp
+++ b/src/cuda/rtc/error.hpp
@@ -192,9 +192,9 @@ inline void throw_if_error(rtc::status_t<Kind> status) noexcept(false)
 
 #define throw_if_rtc_error_lazy(Kind, status__, ... ) \
 do { \
-	rtc::status_t<Kind> tie_status__ = static_cast<rtc::status_t<Kind>>(status__); \
-	if (is_failure<Kind>(tie_status__)) { \
-		throw rtc::runtime_error<Kind>(tie_status__, (__VA_ARGS__)); \
+	::cuda::rtc::status_t<Kind> tie_status__ = static_cast<::cuda::rtc::status_t<Kind>>(status__); \
+	if (::cuda::is_failure<Kind>(tie_status__)) { \
+		throw ::cuda::rtc::runtime_error<Kind>(tie_status__, (__VA_ARGS__)); \
 	} \
 } while(false)
 


### PR DESCRIPTION
`cuda::describe` when on an error in getting the error string with `cuGetErrorString`, now attempts to run `cudaGetErrorString` (from the runtime API) since `cuda::status_t` represents `CUResult` and `cudaError_t`.

The `enqueue_raw_kernel_launch_in_current_context` now also checks for an error with `cudaGetLastError` along with `cuda::outstanding_error::ensure_none`, since kernel launch errors like `cudaErrorInvalidConfiguration` went uncaught.

Changed `src/cuda/rtc/compilation_options.hpp` as follows:  
 ```diff
-template <typename MarshalTarget, typename Delimiter>
-MarshalTarget& operator<<(MarshalTarget& mt, detail_::opt_start_t<Delimiter>& opt_start)
+template <typename Delimiter>
+std::ostream& operator<<(std::ostream& mt, detail_::opt_start_t<Delimiter>& opt_start)
 ```

since there were ~63 compiler errors in the vein of:  
```
C:\local\cuda-api-wrappers\src\cuda\rtc/compilation_options.hpp(585): error : more than one operator "<<" matches these operands:
            function template "MarshalTarget &cuda::rtc::operator<<(MarshalTarget &, cuda::rtc::detail_::opt_start_t<Delimiter> &)"
(489): here
            function template "cuda::rtc::marshalled_options_t &cuda::rtc::marshalled_options_t::operator<<(T &&)"
C:\local\cuda-api-wrappers\src\cuda\rtc\detail/marshalled_options.hpp(53): here
            operand types are: cuda::rtc::marshalled_options_t << cuda::rtc::detail_::opt_start_t<void (*)()>
          detected during:
            instantiation of "void cuda::rtc::process(const cuda::rtc::compilation_options_t<cuda::ptx> &, MarshalTarget &, Delimiter, __nv_bool) [with MarshalTarget=cuda::rtc::marshalled_options_t, Delimiter=void (*)()]"
(689): here
            instantiation of "cuda::rtc::marshalled_options_t cuda::rtc::marshal(const cuda::rtc::compilation_options_t<Kind> &) [with Kind=cuda::ptx]"
C:\local\cuda-api-wrappers\src\cuda\rtc/program.hpp(567): here
```

Updated the macros (`throw_if_error_lazy`, `throw_if_rtc_error_lazy` and `CAW_SET_SCOPE_CONTEXT`) to refer to functions by their absolute paths.