### PR TITLE
correct the documentation of `supports_memory_pools`

### DIFF
--- a/src/cuda/api/device.hpp
+++ b/src/cuda/api/device.hpp
@@ -359,8 +359,8 @@ public:
 
 #if CUDA_VERSION >= 11020
 	/**
-	 * True if this device supports executing kernels in which blocks can
-	 * directly cooperate beyond the use of global-memory atomics.
+	 * True if this device supports integrated memory pool and
+         * stream ordered memory allocator.
 	 */
 	bool supports_memory_pools() const
 	{


### PR DESCRIPTION
The original doc here seems just a copy-paste of `supports_block_cooperation` function.
The new documentation may not be precise enough or easy to understand, and I am happy to cooperate with you to use more precise terms :)