### PR TITLE
msvc build fix

### DIFF
--- a/src/cuda/api/detail/optional.hpp
+++ b/src/cuda/api/detail/optional.hpp
@@ -63,13 +63,6 @@ struct poor_mans_optional {
 		return *this;
 	}
 
-	poor_mans_optional &operator=(const T &&value) noexcept(::std::is_nothrow_move_assignable<T>::value)
-	{
-		has_value_ = true;
-		maybe_value.value = ::std::move(value);
-		return *this;
-	}
-
 	poor_mans_optional &operator=(no_value_t)
 	{
 		has_value_ = false;


### PR DESCRIPTION
These changes just resolved some ambiguity in the assignment operator for `poor_mans_optional<>` in a few locations when building on windows using msvc (should be latest version). I get the same errors from the vcpkg release as well as just including your repo as a submodule. In both cases the build is using cmake and `/std:c++17`.

Let me know if there's a chance something might have just been misconfigured on my end to run into these build errors. Or if the changes seem necessary to resolve these errors, let me know if you'd prefer the template parameter in `pci_id.hpp` to be `int` rather than `cuda::rtc::optimization_level_t` and I can update the PR.

Here's the output of the build prior to these changes:
```bash
03:11:56:531	    0% [0.002s] (0/2)  -Re-checking globbed directories...
03:11:56:531	   50% [0.477s] (1/2)  -Building CXX object CMakeFiles\cuda_analysis.dir\src\main.cpp.obj
03:11:56:531	  FAILED: CMakeFiles/cuda_analysis.dir/src/main.cpp.obj 
03:11:56:531	  C:\PROGRA~1\MICROS~2\2022\COMMUN~1\VC\Tools\MSVC\1440~1.338\bin\Hostx64\x64\cl.exe  /nologo /TP -DBSONCXX_STATIC -DCUDA_API_WRAPPERS_USE_WIN32_THREADS -DCUTLASS_ENABLE_CUBLAS=1 -DCUTLASS_ENABLE_CUDNN=1 -DMONGOCXX_STATIC -IC:\Users\sal\development\vorlac\routeanalytics-cuda\src -IC:\Users\sal\development\vorlac\routeanalytics-cuda\SYSTEM -I\include -IC:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src -external:IC:\Users\sal\development\vorlac\routeanalytics-cuda\.out\build\msvc-debug\vcpkg_installed\x64-windows-static-md\include -external:I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\include" -external:IC:\Users\sal\development\vorlac\routeanalytics-cuda\.out\build\msvc-debug\vcpkg_installed\x64-windows-static-md\include\bsoncxx\v_noabi -external:IC:\Users\sal\development\vorlac\routeanalytics-cuda\.out\build\msvc-debug\vcpkg_installed\x64-windows-static-md\include\mongocxx\v_noabi -external:W0 /DWIN32 /D_WINDOWS /EHsc /Zi /Ob0 /Od /RTC1 -std:c++17 -MDd /std:c++17 /utf-8 -openmp /showIncludes /FoCMakeFiles\cuda_analysis.dir\src\main.cpp.obj /FdCMakeFiles\cuda_analysis.dir\ /FS -c C:\Users\sal\development\vorlac\routeanalytics-cuda\src\main.cpp
03:11:56:531	C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail\pci_id.hpp(57): error C2593: 'operator =' is ambiguous
03:11:56:531	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(79): note: could be 'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(T &&) noexcept(<expr>)'
03:11:56:531	          with
03:11:56:531	          [
03:11:56:531	              T=int
03:11:56:531	          ]
03:11:56:531	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(73): note: or       'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(cuda::detail_::no_value_t)'
03:11:56:532	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(66): note: or       'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(const T &&) noexcept(<expr>)'
03:11:56:532	          with
03:11:56:532	          [
03:11:56:532	              T=int
03:11:56:532	          ]
03:11:56:532	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(59): note: or       'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(const T &) noexcept(<expr>)'
03:11:56:532	          with
03:11:56:532	          [
03:11:56:532	              T=int
03:11:56:532	          ]
03:11:56:532	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(57): note: or       'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(cuda::detail_::poor_mans_optional<int> &&) noexcept'
03:11:56:532	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(55): note: or       'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(const cuda::detail_::poor_mans_optional<int> &) noexcept'
03:11:56:532	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api/detail/pci_id.hpp(57): note: while trying to match the argument list '(cuda::detail_::poor_mans_optional<int>, initializer list)'
03:11:56:532	C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail\pci_id.hpp(72): error C2593: 'operator =' is ambiguous
03:11:56:532	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(79): note: could be 'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(T &&) noexcept(<expr>)'
03:11:56:532	          with
03:11:56:532	          [
03:11:56:532	              T=int
03:11:56:532	          ]
03:11:56:532	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(73): note: or       'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(cuda::detail_::no_value_t)'
03:11:56:533	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(66): note: or       'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(const T &&) noexcept(<expr>)'
03:11:56:533	          with
03:11:56:533	          [
03:11:56:533	              T=int
03:11:56:533	          ]
03:11:56:533	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(59): note: or       'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(const T &) noexcept(false)'
03:11:56:533	          with
03:11:56:533	          [
03:11:56:533	              T=int
03:11:56:533	          ]
03:11:56:533	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(57): note: or       'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(cuda::detail_::poor_mans_optional<int> &&) noexcept'
03:11:56:533	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(55): note: or       'cuda::detail_::poor_mans_optional<int> &cuda::detail_::poor_mans_optional<int>::operator =(const cuda::detail_::poor_mans_optional<int> &) noexcept'
03:11:56:533	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api/detail/pci_id.hpp(72): note: while trying to match the argument list '(cuda::detail_::poor_mans_optional<int>, initializer list)'
03:11:56:534	C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\rtc\compilation_options.hpp(482): error C2593: 'operator =' is ambiguous
03:11:56:534	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(79): note: could be 'cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t> &cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t>::operator =(T &&) noexcept(<expr>)'
03:11:56:534	          with
03:11:56:534	          [
03:11:56:534	              T=cuda::rtc::cpp_dialect_t
03:11:56:534	          ]
03:11:56:534	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(73): note: or       'cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t> &cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t>::operator =(cuda::detail_::no_value_t)'
03:11:56:616	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(66): note: or       'cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t> &cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t>::operator =(const T &&) noexcept(<expr>)'
03:11:56:616	          with
03:11:56:616	          [
03:11:56:616	              T=cuda::rtc::cpp_dialect_t
03:11:56:645	          ]
03:11:56:645	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(59): note: or       'cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t> &cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t>::operator =(const T &) noexcept(<expr>)'
03:11:56:646	          with
03:11:56:646	          [
03:11:56:646	              T=cuda::rtc::cpp_dialect_t
03:11:56:646	          ]
03:11:56:646	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(57): note: or       'cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t> &cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t>::operator =(cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t> &&) noexcept'
03:11:56:646	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\api\detail/optional.hpp(55): note: or       'cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t> &cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t>::operator =(const cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t> &) noexcept'
03:11:56:646	  C:\Users\sal\development\vorlac\routeanalytics-cuda\extern\cuda-api-wrappers\src\cuda\rtc/compilation_options.hpp(482): note: while trying to match the argument list '(cuda::detail_::poor_mans_optional<cuda::rtc::cpp_dialect_t>, initializer list)'
03:11:56:646	  ninja: build stopped: subcommand failed.
03:11:56:648	
```