### PR TITLE
minimal cmake version 3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # your platform. They are not finicky with library dependencies, so
 # compatability is very likely. Also, the package's CMake binary will
 # not mistake any other local CMake-related files for its own.
-cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 
 PROJECT(cuda-api-wrappers
 	VERSION 0.8.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # your platform. They are not finicky with library dependencies, so
 # compatability is very likely. Also, the package's CMake binary will
 # not mistake any other local CMake-related files for its own.
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 
 PROJECT(cuda-api-wrappers
 	VERSION 0.8.0


### PR DESCRIPTION
Tiny change in cmake. the minimal required version is 3.17 required by `FindCUDAToolkit` 