### PR TITLE
Fix 713: use pointer as a deleter argument

### DIFF
--- a/src/cuda/api/unique_region.hpp
+++ b/src/cuda/api/unique_region.hpp
@@ -138,7 +138,7 @@ public:
     {
         ::std::swap<region_t>(*this, region);
         if (region.start() != nullptr) {
-            get_deleter()(region);
+            get_deleter()(region.start());
         }
     }
 


### PR DESCRIPTION
Fixed a bug #713 in the `unique_region` class where the deleter was incorrectly called
Added regression test also.