### PR TITLE
Fix cuda::span redefinition and ambiguous constructor errors in CUDA 12

### DIFF
--- a/src/cuda/api/detail/span.hpp
+++ b/src/cuda/api/detail/span.hpp
@@ -3,14 +3,16 @@
  *
  * @brief Contains an implementation of an std::span-like class, @ref cuda::span
  *
- * @note When compiling with C++20 or later, the actual std::span is used instead
+ * @note When compiling with CUDA 12 or C++20, we alias the standard implementations.
  */
 
 #pragma once
 #ifndef CUDA_API_WRAPPERS_SPAN_HPP_
 #define CUDA_API_WRAPPERS_SPAN_HPP_
 
-#if __cplusplus >= 202002L
+#if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 12
+#include <cuda/std/span>
+#elif __cplusplus >= 202002L
 #include <span>
 #else
 #include <type_traits>
@@ -22,8 +24,12 @@
  */
 namespace cuda {
 
-#if __cplusplus >= 202002L
-using ::std::span;
+#if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 12
+template <typename T, std::size_t Extent = ::cuda::std::dynamic_extent>
+using span = ::cuda::std::span<T, Extent>;
+#elif __cplusplus >= 202002L
+template <typename T, std::size_t Extent = ::std::dynamic_extent>
+using span = ::std::span<T, Extent>;
 #else
 /**
  * @brief A "poor man's" span class

--- a/src/cuda/api/detail/unique_span.hpp
+++ b/src/cuda/api/detail/unique_span.hpp
@@ -111,7 +111,7 @@ public: // constructors and destructor
 			deleter_(*this);
 		}
 #ifndef NDEBUG
-		span_type::operator=(span_type{static_cast<T*>(nullptr), 0});
+		span_type::operator=(span_type{static_cast<T*>(nullptr), static_cast<std::size_t>(0)});
 #endif
 	}
 
@@ -160,7 +160,7 @@ protected: // mutators
 	span_type release() noexcept
 	{
 		span_type released { data(), size() };
-		span_type::operator=(span_type{ static_cast<T*>(nullptr), 0 });
+		span_type::operator=(span_type{static_cast<T *>(nullptr), static_cast<std::size_t>(0)});
 		// Note that we are _not_ replacing deleter.
 		return released;
 	}


### PR DESCRIPTION
## Problem
CUDA 12.x introduces `cuda::std::span` via `libcubxx`, which conflicts with the local `cuda::span` definition in this library. 

This causes:
- **C2977**: Template argument count mismatch (2 vs 1).
- **C4099**: Type name conflict (struct vs class) on MSVC.
- **Ambiguous Call**: `unique_span.hpp` constructor fails because `0` is ambiguous between `size_type` and `pointer`.

## Solution
1. **`span.hpp`**: 
   - Uses `template alias` for CUDA 12+ and C++20 to bridge the official 2-parameter `span` with the library's 1-parameter design via default arguments.
   - Updates fallback logic: CUDA 12 -> C++20 -> Local implementation.
2. **`unique_span.hpp`**: 
   - Explicitly casts `0` to `std::size_t` to resolve constructor ambiguity.

## Verification
- Tested with **CUDA 12.4 + MSVC**.
- Backward compatibility maintained for older CUDA/C++ versions.